### PR TITLE
CP-40676: Specify utf-8 encoding explicitly

### DIFF
--- a/cpiofile.py
+++ b/cpiofile.py
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# -*- coding: utf-8 -*-
 
 # SPDX-License-Identifier: MIT
 #


### PR DESCRIPTION
Commit bc9a0551cad0 ("CP-40676: Convert cpiofile.py to UTF-8") changed cpiofile.py to UTF-8 but didn't specify the encoding. This is needed for Python 2.x which doesn't default to UTF-8 (unlike Python 3.x).

Fixes: bc9a0551cad0 ("CP-40676: Convert cpiofile.py to UTF-8")
Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>