### PR TITLE
init: allow 'answerfile' to work without 'install' boot parameter

### DIFF
--- a/doc/parameters.txt
+++ b/doc/parameters.txt
@@ -117,11 +117,6 @@ Startup
 Installer
 ---------
 
-  --install
-
-    Proceed with installation/upgrade.
-
-
   --answerfile=ans
 
     Read answerfile and perform a non-interactive installation

--- a/init
+++ b/init
@@ -104,7 +104,6 @@ def main(args):
     except:
         pass
 
-    operation = None
     ui = tui
     interactive = True
     answer_device = 'all'
@@ -127,9 +126,7 @@ def main(args):
     logger.log("Installer Version %s" % (installer_version,))
     logger.log("Command line args: %s" % str(args))
     for (opt, val) in args.items():
-        if opt == "--install":
-            operation = init_constants.OPERATION_INSTALL
-        elif opt == "--answerfile":
+        if opt == "--answerfile":
             answerfile_address = val
             interactive = False
             if not val.startswith('file://'):
@@ -162,12 +159,6 @@ def main(args):
             use_ibft = True
         elif opt == "--map_netdev":
             netdev_map = val
-
-    # check that an answerfile was specified if we're being non-interactive:
-    if not interactive and not operation:
-        logger.log("No operation specified for answerfile - dropping back to interactive mode.")
-        interactive = True
-        ui = tui
 
     # start the user interface:
     if ui:


### PR DESCRIPTION
Booting the installer with `answerfile=URL` and no `install` to
complement it would just get no effect, with just a cryptic "No
operation specified for answerfile" hidden in the logfile.

The `install` parameter had only one use in the current code: allowing
`answerfile` to be honored, so just ignore it.