### PR TITLE
Keep `xen-pciback.hide` when upgrading

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -318,6 +318,10 @@ def performInstallation(answers, ui_package, interactive):
                                                          default_host_config['dom0-mem'])
                 default_host_config['dom0-vcpus'] = xcp.dom0.default_vcpus(hardware.getHostTotalCPUs(),
                                                                            answers['host-config']['dom0-mem'])
+
+            # Set xen-pciback if necessary.
+            if 'xen-pciback.hide' in answers['host-config']:
+                default_host_config['xen-pciback.hide'] = answers['host-config']['xen-pciback.hide']
         except Exception as e:
             logger.logException(e)
             raise RuntimeError("Failed to get existing installation settings")
@@ -1018,6 +1022,9 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
 
     common_kernel_params = "root=LABEL=%s ro nolvm hpet=disable" % constants.rootfs_label%disk_label_suffix
     kernel_console_params = "console=hvc0"
+
+    if "xen-pciback.hide" in host_config:
+        common_kernel_params += " %s" % host_config["xen-pciback.hide"]
 
     if diskutil.is_iscsi(primary_disk):
         common_kernel_params += " rd.iscsi.ibft=1 rd.iscsi.firmware=1"

--- a/backend.py
+++ b/backend.py
@@ -318,10 +318,6 @@ def performInstallation(answers, ui_package, interactive):
                                                          default_host_config['dom0-mem'])
                 default_host_config['dom0-vcpus'] = xcp.dom0.default_vcpus(hardware.getHostTotalCPUs(),
                                                                            answers['host-config']['dom0-mem'])
-
-            # Set xen-pciback if necessary.
-            if 'xen-pciback.hide' in answers['host-config']:
-                default_host_config['xen-pciback.hide'] = answers['host-config']['xen-pciback.hide']
         except Exception as e:
             logger.logException(e)
             raise RuntimeError("Failed to get existing installation settings")

--- a/product.py
+++ b/product.py
@@ -376,6 +376,14 @@ class ExistingInstallation:
             (dom0_mem, dom0_mem_min, dom0_mem_max) = xcp.dom0.parse_mem(dom0_mem_arg[0])
             if dom0_mem:
                 results['host-config']['dom0-mem'] = dom0_mem / 1024 / 1024
+
+            # Subset of dom0 kernel arguments
+            kernel_args = boot_config.menu[boot_config.default].getKernelArgs()
+
+            #   - xen-pciback.hide
+            pciback = next((x for x in kernel_args if x.startswith('xen-pciback.hide=')), None)
+            if pciback:
+                results['host-config']['xen-pciback.hide'] = pciback
         except:
             pass
         self.unmount_boot()


### PR DESCRIPTION
Get `xen-pciback.hide` from a host's kernel's args 
Give it to the bootloader after the upgrade

This allow a user to keep it's PCI passthrough after an upgrade

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>