### PR TITLE
Keep `sched-gran`grub entry upon upgrade

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1016,6 +1016,9 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
     if rc == 0 and ('1022:7451' in out or '1022:7459' in out):
         common_xen_params += " ioapic_ack=old"
 
+    if "sched-gran" in host_config:
+        common_xen_params += " %s" % host_config["sched-gran"]
+
     common_kernel_params = "root=LABEL=%s ro nolvm hpet=disable" % constants.rootfs_label%disk_label_suffix
     kernel_console_params = "console=hvc0"
 

--- a/product.py
+++ b/product.py
@@ -377,6 +377,11 @@ class ExistingInstallation:
             if dom0_mem:
                 results['host-config']['dom0-mem'] = dom0_mem / 1024 / 1024
 
+            #   - sched-gran
+            sched_gran = next((x for x in xen_args if x.startswith('sched-gran=')), None)
+            if sched_gran:
+                results['host-config']['sched-gran'] = sched_gran
+
             # Subset of dom0 kernel arguments
             kernel_args = boot_config.menu[boot_config.default].getKernelArgs()
 


### PR DESCRIPTION
If a user set the `sched-gran` [through XAPI](https://github.com/xapi-project/xen-api/blob/master/ocaml/xapi/xapi_host.mli#L524), the settings should be preserved after a host upgrade.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>