### PR TITLE
CP-41369: Match Citrix Hypervisor when removing UEFI boot entry

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1152,8 +1152,12 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
     # First remove existing entries
     rc, out, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr"], True, True)
     check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
+
+    # This list ensures that upgrades from previous versions with different
+    # names work, and the current version (so that self-upgrades always work).
+    labels = '|'.join(['XenServer', 'Citrix Hypervisor', branding['product-brand']])
     for line in out.splitlines():
-        match = re.match("Boot([0-9a-fA-F]{4})\\*? +(?:XenServer|%s)$" % branding['product-brand'], line)
+        match = re.match("Boot([0-9a-fA-F]{4})\\*? +(?:%s)$" % (labels,), line)
         if match:
             bootnum = match.group(1)
             rc, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr",


### PR DESCRIPTION
When removing UEFI boot entries during an install or upgrade, the old entry label may be any of the previous version labels so keep a list and match against the list. Also include the current version name in the list so that self-upgrades always work.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>