### PR TITLE
CA-375063: Mount efivarfs when calling efibootmgr

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1086,6 +1086,8 @@ def installBootLoader(mounts, disk, boot_partnum, primary_partnum, target_boot_m
     # prepare extra mounts for installing bootloader:
     util.bindMount("/dev", "%s/dev" % mounts['root'])
     util.bindMount("/sys", "%s/sys" % mounts['root'])
+    if target_boot_mode == TARGET_BOOT_MODE_UEFI:
+        util.bindMount("/sys/firmware/efi/efivars", "%s/sys/firmware/efi/efivars" % mounts['root'])
     util.bindMount("/proc", "%s/proc" % mounts['root'])
 
     try:
@@ -1138,6 +1140,8 @@ def installBootLoader(mounts, disk, boot_partnum, primary_partnum, target_boot_m
     finally:
         # done installing - undo our extra mounts:
         util.umount("%s/proc" % mounts['root'])
+        if target_boot_mode == TARGET_BOOT_MODE_UEFI:
+            util.umount("%s/sys/firmware/efi/efivars" % mounts['root'])
         util.umount("%s/sys" % mounts['root'])
         util.umount("%s/dev" % mounts['root'])
 


### PR DESCRIPTION
If CONFIG_EFI_VARS is enabled, efibootmgr is able to use that deprecated interface when inside a chroot. With newer kernels where that interface is removed completely [1], it requires bind mounting efivarfs at the correct path so that efibootmgr works inside a chroot.

[1] 0f5b2c69a4cb - efi: vars: Remove deprecated 'efivars' sysfs interface

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>