### PR TITLE
CA-369899: NTP Server options, DHCP|Default|Manual|None

### DIFF
--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -264,6 +264,22 @@ Format of 'source' and 'driver-source'
     Specifies the timezone (region/city)
 
 
+  <ntp source="<source>" />
+
+    Specifies the source for NTP servers
+
+    <source> can be any one of dhcp|default|manual|none
+
+    dhcp - use NTP servers from DHCP
+    default - use default NTP servers
+    manual - use provided NTP servers, in this case at least one "<ntp-server>"
+              entry must be specified
+    none - NTP is disabled
+
+    If the "<ntp>" element is not specified, the default shall be "manual" if "<ntp-server>" is specified, "dhcp" if using DHCP, otherwise "default".
+    It is an error to provide "<ntp-server>" if <source> is dhcp|default|none.
+
+
   <ntp-server>ntp</ntp-server>*
   <ntp-servers>ntp</ntp-servers>*[D]
 

--- a/product.py
+++ b/product.py
@@ -217,7 +217,7 @@ class ExistingInstallation:
             results['root-password'] = ('pwdhash', root_pwd)
 
             # don't care about this too much.
-            results['time-config-method'] = 'ntp'
+            results['ntp-config-method'] = 'default'
 
             # read network configuration.  We only care to find out what the
             # management interface is, and what its configuration was.


### PR DESCRIPTION
Clearing up time settings during install
New settings appear like this when using DHCP IP:
![newoptions](https://github.com/xenserver/host-installer/assets/47088217/3810236e-4af2-4561-9363-4cc3919ae66c)

Which leads to a new manual time setting screen like this:
![nontp](https://github.com/xenserver/host-installer/assets/47088217/a239e246-0a85-467d-96ed-cdafcd158c0d)

The manual NTP server entry has also be stripped down to just entry of the servers (automatically enabled) - I forgot to grab a picture, let me know if you want to see it
New settings when using static IP:
![staticoptions](https://github.com/xenserver/host-installer/assets/47088217/a1955f0a-2aa4-45ef-8f4a-cc835d7e2968)
