### PR TITLE
Drop depmod config files

### DIFF
--- a/startup/depmod.conf
+++ b/startup/depmod.conf
@@ -1,1 +1,0 @@
-search updates extra built-in weak-updates


### PR DESCRIPTION
This old depmod.conf is the default in el7, the fix was made upstream in rhel years ago.

Also drop its companion systemd hook to run `depmod -a`.