### PR TITLE
Keep user multipath configuration upon upgrade

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -683,6 +683,9 @@ class ThirdGenUpgrader(Upgrader):
         restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
         restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
 
+        # Keep user multipath configuration
+        restore_list += [{'dir': 'etc/multipath/conf.d', 're': re.compile(r'custom.*\.conf')}]
+
         return restore_list
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']


### PR DESCRIPTION
All files matchin `custom.*\.conf` will be kept upon upgrade.


See: https://github.com/xapi-project/sm/pull/600