### PR TITLE
util.URL: implement missing bits for extra-repos

### DIFF
--- a/util.py
+++ b/util.py
@@ -388,6 +388,9 @@ class URL(object):
 
             return self.url
 
+    def __repr__(self):
+        return "'" + self.__str__() + "'"
+
     def getScheme(self):
         return self.scheme
 


### PR DESCRIPTION
When answers are dumped to log, URL sources in extra-repos were serialized in a non-human-readable way.  This allows to get the URL printed instead of an opaque object description.