### PR TITLE
CP-43949: Raise exception when we can't find networkd.db

### DIFF
--- a/product.py
+++ b/product.py
@@ -228,6 +228,7 @@ class ExistingInstallation:
 
             if not mgmt_iface:
                 logger.log('No existing management interface found.')
+                raise SettingsNotAvailable("Could not find network configuration")
             elif os.path.exists(self.join_state_path(constants.NETWORK_DB)):
                 logger.log('Checking %s for management interface configuration' % constants.NETWORKD_DB)
 
@@ -280,6 +281,9 @@ class ExistingInstallation:
                     results['net-admin-configuration'].addIPv6(NetInterface.DHCP)
                 elif protov6 == 'autoconf':
                     results['net-admin-configuration'].addIPv6(NetInterface.Autoconf)
+            else:
+                logger.log("Failed to find " + self.join_state_path(constants.NETWORK_DB))
+                raise SettingsNotAvailable("Could not find network configuration")
 
             repo_list = []
             if os.path.exists(self.join_state_path(constants.INSTALLED_REPOS_DIR)):


### PR DESCRIPTION
This covers the case where we have a management interface (mgmt_iface) from /etc/xensource-inventory but we can't find networkd.db in the installation (in the case where we've started an install/upgrade but it was interrupted)

net-admin-bridge or net-admin-interface is required by performInstallation, the failure if they are missing is abstract and unhelpful, this change will fail earlier and more clearly