### PR TITLE
CA-384265: Remove use of cmp to fix XS9 installation

### DIFF
--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -537,8 +537,7 @@ def disk_more_info(context):
     return True
 
 def sorted_disk_list(): # Smallest to largest, then alphabetical
-    return sorted(diskutil.getQualifiedDiskList(),
-                  key=functools.cmp_to_key(lambda x, y: len(x) == len(y) and cmp(x,y) or (len(x)-len(y))))
+    return sorted(diskutil.getQualifiedDiskList(), key=lambda disk: (len(disk), disk))
 
 # select drive to use as the Dom0 disk:
 def select_primary_disk(answers):


### PR DESCRIPTION
XS9 installation failed due to *cmp* is used as *cmp* is only available in python2 while XS9 is based on python3