### PR TITLE
CA-385350 Fix handling of NTP configuration over upgrade

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -154,6 +154,9 @@ ROLLING_POOL_DIR = "boot/installer"
 HYPERVISOR_CAPS_FILE = "/sys/hypervisor/properties/capabilities"
 SAFE_2_UPGRADE = "var/preserve/safe2upgrade"
 
+# NTP server domains to treat as 'default' servers
+DEFAULT_NTP_DOMAINS = [".centos.pool.ntp.org", ".xenserver.pool.ntp.org"]
+
 # timer to exit installer after fatal error
 AUTO_EXIT_TIMER = 10 * 1000
 


### PR DESCRIPTION
Previously we were not setting `ntp-config-method` when parsing the NTP configuration from an old version, resulting in any NTP servers that were read being ignored.

Set the appropriate `ntp-config-method`, and also filter out any 'default' NTP servers from the `ntp-servers` list so we only load customer specified servers. Note this is done using a fixed list of default domains, as this has changed in the past and may change in future, so cannot be read from the current release config.