### PR TITLE
Include mmcblk-devices in disk selection

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -490,7 +490,7 @@ def diskDevice(partitionDevice):
 
 def determineMidfix(device):
     DISK_PREFIX = '/dev/'
-    P_STYLE_DISKS = [ 'cciss', 'ida', 'rd', 'sg', 'i2o', 'amiraid', 'iseries', 'emd', 'carmel', 'mapper/', 'nvme', 'md' ]
+    P_STYLE_DISKS = [ 'cciss', 'ida', 'rd', 'sg', 'i2o', 'amiraid', 'iseries', 'emd', 'carmel', 'mapper/', 'nvme', 'md', 'mmcblk' ]
     PART_STYLE_DISKS = [ 'disk/by-id' ]
 
     for key in P_STYLE_DISKS:

--- a/diskutil.py
+++ b/diskutil.py
@@ -113,6 +113,9 @@ for major in range(72, 80) + range(104, 112):
 for major in range(48, 56):
     disk_nodes += [ (major, x * 8) for x in range(32) ]
 
+# /dev/mmcblk: mmcblk has major 179, each device usually (per kernel) has 7 minors
+disk_nodes += [ (179, x * 8) for x in range(32) ]
+
 def getDiskList():
     # read the partition tables:
     parts = open("/proc/partitions")


### PR DESCRIPTION
This is a small patch we're carrying in xcp-ng for some time, essentially useful to people installing in their home labs.