### PR TITLE
Use explicit integer division where necessary

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -299,7 +299,7 @@ def performInstallation(answers, ui_package, interactive):
 
     dom0_mem = xcp.dom0.default_memory_for_version(
                     hardware.getHostTotalMemoryKB(),
-                    Version.from_string(version.PLATFORM_VERSION)) / 1024
+                    Version.from_string(version.PLATFORM_VERSION)) // 1024
     dom0_vcpus = xcp.dom0.default_vcpus(hardware.getHostTotalCPUs(), dom0_mem)
     default_host_config = { 'dom0-mem': dom0_mem,
                             'dom0-vcpus': dom0_vcpus,

--- a/diskutil.py
+++ b/diskutil.py
@@ -331,10 +331,10 @@ def isRemovable(path):
         return False
 
 def blockSizeToGBSize(blocks):
-    return (int(blocks) * 512) / (1024 * 1024 * 1024)
+    return (int(blocks) * 512) // (1024 * 1024 * 1024)
 
 def blockSizeToMBSize(blocks):
-    return (int(blocks) * 512) / (1024 * 1024)
+    return (int(blocks) * 512) // (1024 * 1024)
 
 def getHumanDiskSize(blocks):
     gb = blockSizeToGBSize(blocks)
@@ -345,7 +345,7 @@ def getHumanDiskSize(blocks):
 
 def getExtendedDiskInfo(disk, inMb=0):
     return (getDiskDeviceVendor(disk), getDiskDeviceModel(disk),
-            inMb and (getDiskDeviceSize(disk)/2048) or getDiskDeviceSize(disk))
+            inMb and (getDiskDeviceSize(disk)//2048) or getDiskDeviceSize(disk))
 
 
 def readExtPartitionLabel(partition):

--- a/install.py
+++ b/install.py
@@ -216,7 +216,7 @@ def go(ui, args, answerfile_address, answerfile_script):
         status = constants.EXIT_OK
 
         # how much RAM do we have?
-        ram_found_mb = hardware.getHostTotalMemoryKB() / 1024
+        ram_found_mb = hardware.getHostTotalMemoryKB() // 1024
         ram_warning = ram_found_mb < constants.MIN_SYSTEM_RAM_MB
         vt_warning = not hardware.VTSupportEnabled()
 

--- a/product.py
+++ b/product.py
@@ -390,7 +390,7 @@ class ExistingInstallation:
             dom0_mem_arg = [x for x in xen_args if x.startswith('dom0_mem')]
             (dom0_mem, dom0_mem_min, dom0_mem_max) = xcp.dom0.parse_mem(dom0_mem_arg[0])
             if dom0_mem:
-                results['host-config']['dom0-mem'] = dom0_mem / 1024 / 1024
+                results['host-config']['dom0-mem'] = dom0_mem // (1024*1024)
 
             #   - sched-gran
             sched_gran = next((x for x in xen_args if x.startswith('sched-gran=')), None)


### PR DESCRIPTION
By default in Python 3 a division, even between integers, is done using floating point. This causes the result to be float and potentially reduce precision (float precision is 52 bits).

To avoid changes in behaviour between Python 2 and Python 3 and possible precision losses use explicit integer divisions that will produce same results.