### PR TITLE
Use explicit integer division where necessary

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -298,7 +298,7 @@ def performInstallation(answers, ui_package, interactive):
 
     dom0_mem = xcp.dom0.default_memory_for_version(
                     hardware.getHostTotalMemoryKB(),
-                    Version.from_string(version.PLATFORM_VERSION)) / 1024
+                    Version.from_string(version.PLATFORM_VERSION)) // 1024
     dom0_vcpus = xcp.dom0.default_vcpus(hardware.getHostTotalCPUs(), dom0_mem)
     default_host_config = { 'dom0-mem': dom0_mem,
                             'dom0-vcpus': dom0_vcpus,

--- a/disktools.py
+++ b/disktools.py
@@ -318,13 +318,13 @@ class LVMTool:
             raise Exception("Size requested for "+str(device)+" ("+str(byteSize)+
                 ") is greater than device size ("+str(pv['dev_size'])+")")
 
-        extentBytes = pv['pv_size'] / pv['pv_pe_count'] # Typically 4MiB
+        extentBytes = pv['pv_size'] // pv['pv_pe_count'] # Typically 4MiB
         # Calculate the threshold in extents beyond which segments must be moved elsewhere.
         # Round down, so enough space is freed for pvresize to complete, and allow
         # PVRESIZE_EXTENT_MARGIN for extents consumed by LVM metadata
-        metadataExtents = (pv['pe_start'] + extentBytes - 1) / extentBytes # Round up
+        metadataExtents = (pv['pe_start'] + extentBytes - 1) // extentBytes # Round up
 
-        thresholdExtent = byteSize / extentBytes - metadataExtents - self.PVRESIZE_EXTENT_MARGIN
+        thresholdExtent = byteSize // extentBytes - metadataExtents - self.PVRESIZE_EXTENT_MARGIN
         self.makeSpaceAfterThreshold(device, thresholdExtent)
         self.resizeList.append({'device' : device, 'bytesize' : byteSize})
 
@@ -468,7 +468,7 @@ class LVMTool:
         # Process resize list
         progress_callback(98)
         for resize in self.resizeList:
-            self.cmdWrap(self.PVRESIZE + ['--setphysicalvolumesize', str(resize['bytesize']/1024)+'k', resize['device']])
+            self.cmdWrap(self.PVRESIZE + ['--setphysicalvolumesize', str(resize['bytesize']//1024)+'k', resize['device']])
         self.resizeList = []
 
         self.readAllInfo() # Reread the new LVM configuration
@@ -609,7 +609,7 @@ class PartitionToolBase:
         else:
             if startBytes % self.sectorSize != 0:
                 raise Exception("Partition start ("+str(startBytes)+") is not a multiple of the sector size "+str(self.sectorSize))
-            startSector = startBytes / self.sectorSize
+            startSector = startBytes // self.sectorSize
 
         if sizeBytes is None:
             if order:
@@ -627,7 +627,7 @@ class PartitionToolBase:
             if sizeBytes % self.sectorSize != 0:
                 raise Exception("Partition size ("+str(sizeBytes)+") is not a multiple of the sector size "+str(self.sectorSize))
 
-            sizeSectors = sizeBytes / self.sectorSize
+            sizeSectors = sizeBytes // self.sectorSize
 
         if sizeSectors < 0:
             self.dump()
@@ -685,7 +685,7 @@ class PartitionToolBase:
         if sizeBytes % self.sectorSize != 0:
             raise Exception("Partition size ("+str(sizeBytes)+") is not a multiple of the sector size "+str(self.sectorSize))
 
-        self.partitions[number]['size'] = sizeBytes / self.sectorSize
+        self.partitions[number]['size'] = sizeBytes // self.sectorSize
 
     def setActiveFlag(self, activeFlag, number):
         assert isinstance(activeFlag, types.BooleanType) # Assert that params are the right way around
@@ -753,7 +753,7 @@ class DOSPartitionTool(PartitionToolBase):
         # DOS partition tables have 32bit sector addresses so we may need to truncate sectorExtent
         # Actually truncate a bit more because sfdisk has unfathomablely lower limit
         self.sectorExtent = min([self.sectorExtent, 0xffe00000]) # 2047G
-        cylinders = int(self.sectorExtent/(heads * sectors))
+        cylinders = int(self.sectorExtent//(heads * sectors))
         self.sectorExtent = cylinders * heads * sectors # Ignore partial cylinder at end
 
         self.sectorFirstUsable = sectors # Some SANs require bootable disks to start on sector boundary
@@ -781,11 +781,11 @@ class DOSPartitionTool(PartitionToolBase):
         sectors = 63
         self.sectorSize = 512
         out = self.cmdWrap([self.BLOCKDEV, '--getsize64', self.device])
-        self.sectorExtent = int(out)/self.sectorSize
+        self.sectorExtent = int(out)//self.sectorSize
         # DOS partition tables have 32bit sector addresses so we may need to truncate sectorExtent
         # Actually truncate a bit more because sfdisk has unfathomablely lower limit
         self.sectorExtent = min([self.sectorExtent, 0xffe00000]) # 2047G
-        cylinders = int(self.sectorExtent/(heads * sectors))
+        cylinders = int(self.sectorExtent//(heads * sectors))
         self.sectorExtent = cylinders * heads * sectors # Ignore partial cylinder at end
         self.sectorFirstUsable = sectors # Some SANs require bootable disks to start on sector boundary
         self.sectorLastUsable = self.sectorExtent - 1
@@ -866,7 +866,7 @@ class DOSPartitionTool(PartitionToolBase):
                 raise Exception('Failed to destroy partitions on ' + self.device)
             heads = 255
             sectors = 63
-            cylinders = self.sectorExtent/(heads * sectors)
+            cylinders = self.sectorExtent//(heads * sectors)
             cmd = [self.SFDISK, dryrun and '-Lnu' or '-Lu', '--no-reread', '-f', '-C%d' % cylinders, '-H%d' % heads, '-S%d' % sectors, self.device]
         else:
             cmd = [self.SFDISK, dryrun and '-LnuS' or '-LuS', '--no-reread', '-f', self.device]
@@ -889,7 +889,7 @@ class DOSPartitionTool(PartitionToolBase):
             if rv:
                 raise Exception('Failed to create partitions on %s using kpartx ' % self.device)
             for number in table.keys():
-                size = int(self.cmdWrap([self.BLOCKDEV, '--getsize64', '%sp%d' % (self.device, number)]))/self.sectorSize
+                size = int(self.cmdWrap([self.BLOCKDEV, '--getsize64', '%sp%d' % (self.device, number)]))//self.sectorSize
                 if size != table[number]['size']:
                     raise Exception('Failed to create partition %sp%d of size %d' % (self.device, number, table[number]['size']))
 
@@ -939,7 +939,7 @@ class GPTPartitionTool(PartitionToolBase):
 
     def readDiskDetails(self):
         self.sectorSize        = int(self.cmdWrap(['blockdev', '--getss', self.device]))
-        self.sectorExtent      = int(self.cmdWrap(['blockdev', '--getsize64', self.device])) / self.sectorSize
+        self.sectorExtent      = int(self.cmdWrap(['blockdev', '--getsize64', self.device])) // self.sectorSize
         self.sectorFirstUsable = 34
         self.sectorLastUsable  = self.sectorExtent - 34
         self.sectorAlignment   = 2 ** 20 // self.sectorSize

--- a/diskutil.py
+++ b/diskutil.py
@@ -332,10 +332,10 @@ def isRemovable(path):
         return False
 
 def blockSizeToGBSize(blocks):
-    return (long(blocks) * 512) / (1024 * 1024 * 1024)
+    return (long(blocks) * 512) // (1024 * 1024 * 1024)
 
 def blockSizeToMBSize(blocks):
-    return (long(blocks) * 512) / (1024 * 1024)
+    return (long(blocks) * 512) // (1024 * 1024)
 
 def getHumanDiskSize(blocks):
     gb = blockSizeToGBSize(blocks)
@@ -346,7 +346,7 @@ def getHumanDiskSize(blocks):
 
 def getExtendedDiskInfo(disk, inMb=0):
     return (getDiskDeviceVendor(disk), getDiskDeviceModel(disk),
-            inMb and (getDiskDeviceSize(disk)/2048) or getDiskDeviceSize(disk))
+            inMb and (getDiskDeviceSize(disk)//2048) or getDiskDeviceSize(disk))
 
 
 def readExtPartitionLabel(partition):

--- a/install.py
+++ b/install.py
@@ -216,7 +216,7 @@ def go(ui, args, answerfile_address, answerfile_script):
         status = constants.EXIT_OK
 
         # how much RAM do we have?
-        ram_found_mb = hardware.getHostTotalMemoryKB() / 1024
+        ram_found_mb = hardware.getHostTotalMemoryKB() // 1024
         ram_warning = ram_found_mb < constants.MIN_SYSTEM_RAM_MB
         vt_warning = not hardware.VTSupportEnabled()
 

--- a/product.py
+++ b/product.py
@@ -390,7 +390,7 @@ class ExistingInstallation:
             dom0_mem_arg = filter(lambda x: x.startswith('dom0_mem'), xen_args)
             (dom0_mem, dom0_mem_min, dom0_mem_max) = xcp.dom0.parse_mem(dom0_mem_arg[0])
             if dom0_mem:
-                results['host-config']['dom0-mem'] = dom0_mem / 1024 / 1024
+                results['host-config']['dom0-mem'] = dom0_mem // (1024*1024)
 
             #   - sched-gran
             sched_gran = next((x for x in xen_args if x.startswith('sched-gran=')), None)


### PR DESCRIPTION
By default in Python 3 a division, even between integers, is done using floating point. This causes the result to be float and potentially reduce precision (float precision is 52 bits).

To avoid changes in behaviour between Python 2 and Python 3 and possible precision losses use explicit integer divisions that will produce same results.

This is just a backport of https://github.com/xenserver/host-installer/pull/83. Although the behaviour won't change as this branch is using Python 2 having in place will make easier to port patches between the 2 branches.