### PR TITLE
Use constant octal syntax compatible with Python3

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1584,7 +1584,7 @@ def configureNetworking(mounts, admin_iface, admin_bridge, admin_config, hn_conf
 
     # EA-1069 - write static-rules.conf and dynamic-rules.conf
     if not os.path.exists(os.path.join(mounts['root'], 'etc/sysconfig/network-scripts/interface-rename-data/.from_install/')):
-        os.makedirs(os.path.join(mounts['root'], 'etc/sysconfig/network-scripts/interface-rename-data/.from_install/'), 0775)
+        os.makedirs(os.path.join(mounts['root'], 'etc/sysconfig/network-scripts/interface-rename-data/.from_install/'), 0o775)
 
     netutil.static_rules.path = os.path.join(mounts['root'], 'etc/sysconfig/network-scripts/interface-rename-data/static-rules.conf')
     netutil.static_rules.save()

--- a/cpiofile.py
+++ b/cpiofile.py
@@ -77,26 +77,26 @@ HEADERSIZE_SVR4 = 110                # length of fixed header
 #---------------------------------------------------------
 # Bits used in the mode field, values in octal.
 #---------------------------------------------------------
-S_IFLNK = 0120000        # symbolic link
-S_IFREG = 0100000        # regular file
-S_IFBLK = 0060000        # block device
-S_IFDIR = 0040000        # directory
-S_IFCHR = 0020000        # character device
-S_IFIFO = 0010000        # fifo
+S_IFLNK = 0o120000        # symbolic link
+S_IFREG = 0o100000        # regular file
+S_IFBLK = 0o060000        # block device
+S_IFDIR = 0o040000        # directory
+S_IFCHR = 0o020000        # character device
+S_IFIFO = 0o010000        # fifo
 
-TSUID   = 04000          # set UID on execution
-TSGID   = 02000          # set GID on execution
-TSVTX   = 01000          # reserved
+TSUID   = 0o4000          # set UID on execution
+TSGID   = 0o2000          # set GID on execution
+TSVTX   = 0o1000          # reserved
 
-TUREAD  = 0400           # read by owner
-TUWRITE = 0200           # write by owner
-TUEXEC  = 0100           # execute/search by owner
-TGREAD  = 0040           # read by group
-TGWRITE = 0020           # write by group
-TGEXEC  = 0010           # execute/search by group
-TOREAD  = 0004           # read by other
-TOWRITE = 0002           # write by other
-TOEXEC  = 0001           # execute/search by other
+TUREAD  = 0o400           # read by owner
+TUWRITE = 0o200           # write by owner
+TUEXEC  = 0o100           # execute/search by owner
+TGREAD  = 0o040           # read by group
+TGWRITE = 0o020           # write by group
+TGEXEC  = 0o010           # execute/search by group
+TOREAD  = 0o004           # read by other
+TOWRITE = 0o002           # write by other
+TOEXEC  = 0o001           # execute/search by other
 
 #---------------------------------------------------------
 # Some useful functions
@@ -754,7 +754,7 @@ class CpioInfo(object):
            of the member.
         """
         self.ino = 0            # i-node
-        self.mode = S_IFREG | 0444
+        self.mode = S_IFREG | 0o444
         self.uid = 0            # user id
         self.gid = 0            # group id
         self.nlink = 1          # number of links
@@ -1323,7 +1323,7 @@ class CpioFile(object):
                 # Extract directory with a safe mode, so that
                 # all files below can be extracted as well.
                 try:
-                    os.makedirs(os.path.join(path, cpioinfo.name), 0777)
+                    os.makedirs(os.path.join(path, cpioinfo.name), 0o777)
                 except EnvironmentError:
                     pass
                 directories.append(cpioinfo)
@@ -1430,7 +1430,7 @@ class CpioFile(object):
         if upperdirs and not os.path.exists(upperdirs):
             ti = CpioInfo()
             ti.name  = upperdirs
-            ti.mode  = stat.S_IFDIR | 0777
+            ti.mode  = stat.S_IFDIR | 0o777
             ti.mtime = cpioinfo.mtime
             ti.uid   = cpioinfo.uid
             ti.gid   = cpioinfo.gid

--- a/repository.py
+++ b/repository.py
@@ -331,7 +331,7 @@ gpgkey=file://%s
         # It is created after the yum install phase.
         confdir = os.path.join(root, 'etc', 'dracut.conf.d')
         self._conffile = os.path.join(confdir, 'xs_disable.conf')
-        os.makedirs(confdir, 0775)
+        os.makedirs(confdir, 0o775)
         with open(self._conffile, 'w') as f:
             print >> f, 'echo Skipping initrd creation during host installation'
             print >> f, 'exit 0'

--- a/upgrade.py
+++ b/upgrade.py
@@ -342,7 +342,7 @@ class ThirdGenUpgrader(Upgrader):
                     if x in just_dirs:
                         path = os.path.join(backup_fs.mount_point, x)
                         if not os.path.exists(path):
-                            os.mkdir(path, 0755)
+                            os.mkdir(path, 0o755)
                     else:
                         cmd = ['cp', '-a'] + \
                               [ os.path.join(primary_fs.mount_point, x) ] + \


### PR DESCRIPTION
This change reduces the difference between Python2 and Python3 making easier to cherry pick or rebase commits from a branch to another.