### PR TITLE
Remove useless check - TRIVIAL

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -592,9 +592,7 @@ class PartitionToolBase:
         partitions = [None] + [part for num, part in sorted(self.partitions.items(), key=lambda item: item[1]['start'])]
 
         if startBytes is None:
-            if len(partitions) == 0:
-                startSector = self.sectorFirstUsable
-            elif order:
+            if order:
                 if order < 1:
                     raise Exception("Order cannot be less than 1")
                 elif order == 1:


### PR DESCRIPTION
partitions has always at least one elements (a dummy None one) so if can't have a length of 0.