### PR TITLE
Allows to restore really old layout used by NetScaler SDX machines

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -526,7 +526,7 @@ def configureNTP(mounts, ntp_config_method, ntp_servers):
 
 # This is attempting to understand the desired layout of the future partitioning
 # based on options passed and status of disk (like partition to retain).
-# This is used on upgrade or restore.
+# This should be used for upgrade or install, not for restore.
 # Returns 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'backup-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum'
 def partitionTargetDisk(disk, existing, preserve_first_partition, create_sr_part):
     logger.log("Installer booted in %s mode" % ("UEFI" if constants.UEFI_INSTALLER else "legacy"))

--- a/backend.py
+++ b/backend.py
@@ -104,7 +104,7 @@ def getPrepSequence(ans, interactive):
         Task(util.getUUID, As(ans), ['installation-uuid']),
         Task(util.getUUID, As(ans), ['control-domain-uuid']),
         Task(util.randomLabelStr, As(ans), ['disk-label-suffix']),
-        Task(inspectTargetDisk, A(ans, 'primary-disk', 'installation-to-overwrite', 'preserve-first-partition','sr-on-primary'), ['target-boot-mode', 'boot-partnum', 'primary-partnum', 'backup-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum']),
+        Task(partitionTargetDisk, A(ans, 'primary-disk', 'installation-to-overwrite', 'preserve-first-partition','sr-on-primary'), ['target-boot-mode', 'boot-partnum', 'primary-partnum', 'backup-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum']),
         ]
 
     if ans['ntp-config-method'] in ("dhcp", "default", "manual"):
@@ -524,7 +524,11 @@ def configureNTP(mounts, ntp_config_method, ntp_servers):
     util.runCmd2(['chroot', mounts['root'], 'systemctl', 'enable', 'chronyd'])
     util.runCmd2(['chroot', mounts['root'], 'systemctl', 'enable', 'chrony-wait'])
 
-def inspectTargetDisk(disk, existing, preserve_first_partition, create_sr_part):
+# This is attempting to understand the desired layout of the future partitioning
+# based on options passed and status of disk (like partition to retain).
+# This is used on upgrade or restore.
+# Returns 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'backup-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum'
+def partitionTargetDisk(disk, existing, preserve_first_partition, create_sr_part):
     logger.log("Installer booted in %s mode" % ("UEFI" if constants.UEFI_INSTALLER else "legacy"))
 
     primary_part = 1

--- a/diskutil.py
+++ b/diskutil.py
@@ -456,14 +456,15 @@ STORAGE_EXT3 = 2
 
 def probeDisk(device, justInstall=False):
     """Examines device and reports the apparent presence of a XenServer installation and/or related usage
-    Returns a tuple (boot, state, storage)
+    Returns a tuple (boot, root, state, storage, logs)
 
     Where:
 
         boot is a tuple of True or False and the partition device
-        root is a tuple of None, INSTALL_RETAIL and the partition device
+        root is a tuple of None or INSTALL_RETAIL and the partition device
         state is a tuple of True or False and the partition device
         storage is a tuple of None, STORAGE_LVM or STORAGE_EXT3 and the partition device
+        logs is a tuple of True or False and the partition device
     """
 
     boot = (False, None)

--- a/diskutil.py
+++ b/diskutil.py
@@ -454,7 +454,7 @@ INSTALL_RETAIL = 1
 STORAGE_LVM = 1
 STORAGE_EXT3 = 2
 
-def probeDisk(device, justInstall=False):
+def probeDisk(device):
     """Examines device and reports the apparent presence of a XenServer installation and/or related usage
     Returns a tuple (boot, root, state, storage, logs)
 
@@ -501,20 +501,19 @@ def probeDisk(device, justInstall=False):
         elif part['id'] == GPTPartitionTool.ID_EFI_BOOT or part['id'] == GPTPartitionTool.ID_BIOS_BOOT:
             boot = (True, part_device)
 
-    if not justInstall:
-        lv_tool = len(possible_srs) and LVMTool()
-        for num in possible_srs:
-            part_device = tool._partitionDevice(num)
+    lv_tool = len(possible_srs) and LVMTool()
+    for num in possible_srs:
+        part_device = tool._partitionDevice(num)
 
-            if lv_tool.isPartitionConfig(part_device):
-                state = (True, part_device)
-            elif lv_tool.isPartitionSR(part_device):
-                pv = lv_tool.deviceToPVOrNone(part_device)
-                if pv is not None and pv['vg_name'].startswith(lv_tool.VG_EXT_SR_PREFIX):
-                    # odd 'ext3 in an LV' SR
-                    storage = (STORAGE_EXT3, part_device)
-                else:
-                    storage = (STORAGE_LVM, part_device)
+        if lv_tool.isPartitionConfig(part_device):
+            state = (True, part_device)
+        elif lv_tool.isPartitionSR(part_device):
+            pv = lv_tool.deviceToPVOrNone(part_device)
+            if pv is not None and pv['vg_name'].startswith(lv_tool.VG_EXT_SR_PREFIX):
+                # odd 'ext3 in an LV' SR
+                storage = (STORAGE_EXT3, part_device)
+            else:
+                storage = (STORAGE_LVM, part_device)
 
     logger.log('Probe of %s found boot=%s root=%s state=%s storage=%s logs=%s' %
                   (device, str(boot), str(root), str(state), str(storage), str(logs)))

--- a/diskutil.py
+++ b/diskutil.py
@@ -493,7 +493,7 @@ def probeDisk(device):
                 if num + 2 in tool.partitions:
                     # George Retail and earlier didn't use the correct id for SRs
                     possible_srs = [num+2]
-            elif label and label.startswith('logs-'):
+            elif label and label.startswith(constants.logsfs_label_prefix):
                 logs = (True, part_device)
         elif part['id'] == tool.ID_LINUX_LVM:
             if num not in possible_srs:

--- a/product.py
+++ b/product.py
@@ -582,13 +582,13 @@ def findXenSourceProducts():
 
     installs = []
 
-    for disk in diskutil.getQualifiedDiskList():
-        (boot, root, state, storage, _) = diskutil.probeDisk(disk)
+    for disk_device in diskutil.getQualifiedDiskList():
+        disk = diskutil.probeDisk(disk_device)
 
         inst = None
         try:
-            if root[0] == diskutil.INSTALL_RETAIL:
-                inst = ExistingRetailInstallation(disk, boot[1], root[1], state[1], storage)
+            if disk.root[0] == diskutil.INSTALL_RETAIL:
+                inst = ExistingRetailInstallation(disk_device, disk.boot[1], disk.root[1], disk.state[1], disk.storage)
         except Exception as e:
             logger.log("A problem occurred whilst scanning for existing installations:")
             logger.logException(e)

--- a/product.py
+++ b/product.py
@@ -583,7 +583,7 @@ def findXenSourceProducts():
     installs = []
 
     for disk in diskutil.getQualifiedDiskList():
-        (boot, root, state, storage, logs) = diskutil.probeDisk(disk)
+        (boot, root, state, storage, _) = diskutil.probeDisk(disk)
 
         inst = None
         try:

--- a/report.py
+++ b/report.py
@@ -68,10 +68,10 @@ def disk_more_info(context):
     if not context: return True
 
     usage = 'unknown'
-    (_, root, _, storage, _) = diskutil.probeDisk(context)
-    if root[0]:
+    disk = diskutil.probeDisk(context)
+    if disk.root[0]:
         usage = "%s installation" % (PRODUCT_BRAND or PLATFORM_NAME)
-    elif storage[0]:
+    elif disk.storage[0]:
         usage = 'VM storage'
 
     tui.update_help_line([' ', ' '])
@@ -93,8 +93,8 @@ def get_local_disk(answers):
         (vendor, model, size) = diskutil.getExtendedDiskInfo(de)
         # determine current usage
         target_is_sr[de] = False
-        (_, _, _, storage, _) = diskutil.probeDisk(de)
-        if storage[0]:
+        disk = diskutil.probeDisk(de)
+        if disk.storage[0]:
             target_is_sr[de] = True
         (vendor, model, size) = diskutil.getExtendedDiskInfo(de)
         stringEntry = "%s - %s [%s %s]" % (diskutil.getHumanDiskName(de), diskutil.getHumanDiskSize(size), vendor, model)

--- a/report.py
+++ b/report.py
@@ -68,7 +68,7 @@ def disk_more_info(context):
     if not context: return True
 
     usage = 'unknown'
-    (boot, root, state, storage, logs) = diskutil.probeDisk(context)
+    (_, root, _, storage, _) = diskutil.probeDisk(context)
     if root[0]:
         usage = "%s installation" % (PRODUCT_BRAND or PLATFORM_NAME)
     elif storage[0]:
@@ -93,7 +93,7 @@ def get_local_disk(answers):
         (vendor, model, size) = diskutil.getExtendedDiskInfo(de)
         # determine current usage
         target_is_sr[de] = False
-        (boot, root, state, storage, logs) = diskutil.probeDisk(de)
+        (_, _, _, storage, _) = diskutil.probeDisk(de)
         if storage[0]:
             target_is_sr[de] = True
         (vendor, model, size) = diskutil.getExtendedDiskInfo(de)

--- a/restore.py
+++ b/restore.py
@@ -23,8 +23,8 @@ def restoreFromBackup(backup, progress=lambda x: ()):
     bootlabel = None
     disk = backup.root_disk
     tool = PartitionTool(disk)
-    _, _, _, storage, _ = diskutil.probeDisk(disk)
-    create_sr_part = storage[0] is not None
+    dsk = diskutil.probeDisk(disk)
+    create_sr_part = dsk.storage[0] is not None
     _, boot_partnum, primary_partnum, backup_partnum, logs_partnum, swap_partnum, _ = backend.inspectTargetDisk(disk, None, constants.PRESERVE_IF_UTILITY, create_sr_part)
 
     backup_fs = util.TempMount(backup.partition, 'backup-', options=['ro'])

--- a/restore.py
+++ b/restore.py
@@ -25,7 +25,7 @@ def restoreFromBackup(backup, progress=lambda x: ()):
     tool = PartitionTool(disk)
     dsk = diskutil.probeDisk(disk)
     create_sr_part = dsk.storage[0] is not None
-    _, boot_partnum, primary_partnum, backup_partnum, logs_partnum, swap_partnum, _ = backend.inspectTargetDisk(disk, None, constants.PRESERVE_IF_UTILITY, create_sr_part)
+    _, boot_partnum, primary_partnum, backup_partnum, logs_partnum, swap_partnum, _ = backend.partitionTargetDisk(disk, None, constants.PRESERVE_IF_UTILITY, create_sr_part)
 
     backup_fs = util.TempMount(backup.partition, 'backup-', options=['ro'])
     inventory = util.readKeyValueFile(os.path.join(backup_fs.mount_point, constants.INVENTORY_FILE), strip_quotes=True)

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -513,7 +513,7 @@ def disk_more_info(context):
     if not context: return True
 
     usage = 'unknown'
-    (boot, root, state, storage, logs) = diskutil.probeDisk(context)
+    (_, root, _, storage, _) = diskutil.probeDisk(context)
     if root[0]:
         usage = "%s installation" % MY_PRODUCT_BRAND
     elif storage[0]:
@@ -558,7 +558,7 @@ def select_primary_disk(answers):
 
         # determine current usage
         target_is_sr[de] = False
-        (boot, root, state, storage, logs) = diskutil.probeDisk(de)
+        (_, _, _, storage, _) = diskutil.probeDisk(de)
         if storage[0]:
             target_is_sr[de] = True
         e = (diskutil.getHumanDiskLabel(de), de)

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -513,10 +513,10 @@ def disk_more_info(context):
     if not context: return True
 
     usage = 'unknown'
-    (_, root, _, storage, _) = diskutil.probeDisk(context)
-    if root[0]:
+    disk = diskutil.probeDisk(context)
+    if disk.root[0]:
         usage = "%s installation" % MY_PRODUCT_BRAND
-    elif storage[0]:
+    elif disk.storage[0]:
         usage = 'VM storage'
     else:
         # Determine disk is being used as an LVM SR with no partitioning
@@ -558,8 +558,8 @@ def select_primary_disk(answers):
 
         # determine current usage
         target_is_sr[de] = False
-        (_, _, _, storage, _) = diskutil.probeDisk(de)
-        if storage[0]:
+        disk = diskutil.probeDisk(de)
+        if disk.storage[0]:
             target_is_sr[de] = True
         e = (diskutil.getHumanDiskLabel(de), de)
         entries.append(e)


### PR DESCRIPTION
This change allows to restore SDX machines updated to XenServer 8.

SDX still uses MBR and 3 partition schema (plus one possible utility partition). 
The possibility to restore this schema was removed from installer time ago but we need to add back to support restore of SDX products.

After restoring backup data to logs (which used to be the root partition) all additional partitions (EFI boot, swap, logs) not necessary are removed, backup recreated and partition schema is moved from GPT to MBR.

This PR is based on https://github.com/xenserver/host-installer/pull/89 (which contain base improves).

Opened as Draft as I don't like some aspect of it. Maybe just paranoia:

- clearing "manually" the GPT after `sfdisk`... but wiping every entirely before open a window for loosing data which is worst;
- the `Disk` object naming for the return of `probeDisk`... maybe something more like product?
- restore code looks more dirty having to support such an old schema. But not sure how to separate in another way;
- I found weird having to manually convert from GPT to MBR... why this is not done in `disktools.py`?