### PR TITLE
Rewrite error_string function

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -51,25 +51,19 @@ NETWORK_BACKEND_VSWITCH_ALT = "vswitch"
 
 # error strings:
 def error_string(error, logname, with_hd):
-    (
-        ERROR_STRING_UNKNOWN_ERROR_WITH_HD,
-        ERROR_STRING_UNKNOWN_ERROR_WITHOUT_HD,
-        ERROR_STRING_KNOWN_ERROR
-    ) = list(range(3))
-
-    ERROR_STRINGS = {
-        ERROR_STRING_UNKNOWN_ERROR_WITH_HD: "An unrecoverable error has occurred.  The details of the error can be found in the log file, which has been written to /tmp/%s (and /root/%s on your hard disk if possible).\n\nPlease refer to your user guide or contact a Technical Support Representative for more details.",
-        ERROR_STRING_UNKNOWN_ERROR_WITHOUT_HD: "An unrecoverable error has occurred.  The details of the error can be found in the log file, which has been written to /tmp/%s.\n\nPlease refer to your user guide or contact a Technical Support Representative for more details.",
-        ERROR_STRING_KNOWN_ERROR: "An unrecoverable error has occurred.  The error was:\n\n%s\n\nPlease refer to your user guide, or contact a Technical Support Representative, for further details."
-        }
-
+    error = error.rstrip()
     if error == "":
+        err = "The details of the error can be found in the log file, which has been written to /tmp/%s" % logname
         if with_hd:
-            return ERROR_STRINGS[ERROR_STRING_UNKNOWN_ERROR_WITH_HD] % (logname, logname)
-        else:
-            return ERROR_STRINGS[ERROR_STRING_UNKNOWN_ERROR_WITHOUT_HD] % logname
+            err += " (and /root/%s on your hard disk if possible)" % logname
     else:
-        return ERROR_STRINGS[ERROR_STRING_KNOWN_ERROR] % error
+        err = "The error was:\n\n%s" % error
+
+    if err[-1:] != '.':
+        err += '.'
+
+    return ('An unrecoverable error has occurred.  ' + err +
+        '\n\nPlease refer to your user guide or contact a Technical Support Representative for more details.')
 
 # minimum hardware specs:
 # memory checks should be done against MIN_SYSTEM_RAM_MB since libxc

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import sys
+import os.path
+sys.path.append(os.path.join(os.path.abspath(os.path.dirname(__file__)), '..'))
+
+import unittest
+import constants
+
+class TestErrorString(unittest.TestCase):
+    def check(self, error, logname, with_hd, expected):
+        got = constants.error_string(error, logname, with_hd)
+        self.assertEqual(got, expected)
+
+    def test_hello(self):
+        self.check('hello', 'LOGFILE', True, '''An unrecoverable error has occurred.  The error was:
+
+hello.
+
+Please refer to your user guide or contact a Technical Support Representative for more details.''')
+
+    def test_with_dot(self):
+        self.check('hello.', 'LOGFILE', True, '''An unrecoverable error has occurred.  The error was:
+
+hello.
+
+Please refer to your user guide or contact a Technical Support Representative for more details.''')
+
+    def test_empty(self):
+        self.check('', 'LOGFILE', True, '''An unrecoverable error has occurred.  The details of the error can be found in the log file, which has been written to /tmp/LOGFILE (and /root/LOGFILE on your hard disk if possible).
+
+Please refer to your user guide or contact a Technical Support Representative for more details.''')
+
+    def test_empty_without_hd(self):
+        self.check('', 'LOGFILE', False, '''An unrecoverable error has occurred.  The details of the error can be found in the log file, which has been written to /tmp/LOGFILE.
+
+Please refer to your user guide or contact a Technical Support Representative for more details.''')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Avoids duplication of part of the error messages.
Do not declare enumeration or dictionary, just use strings.
Make sure error is terminated with a dot.

This is intended to supersedes https://github.com/xenserver/host-installer/pull/80. 