### PR TITLE
CA-388603: Update misleading message (and code)

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -209,9 +209,8 @@ class ThirdGenUpgrader(Upgrader):
         primary_fs.unmount()
 
     def testUpgradeForbidden(self, tool):
-        utilparts = tool.utilityPartitions()
-        if tool.partTableType == constants.PARTITION_DOS and utilparts is not None:
-            raise RuntimeError("Util partition detected on DOS partition type, upgrade forbidden.")
+        if tool.partTableType == constants.PARTITION_DOS:
+            raise RuntimeError("Upgrade from a DOS partition type is not supported.")
 
     prepTargetStateChanges = []
     prepTargetArgs = ['primary-disk', 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum']


### PR DESCRIPTION
`testUpgradeForbidden` is called to check we can upgrade. The support for upgrading from MBR was removed and trigger a message.
However the message refers to an utility partition even if this partition is not present.
Looking at code we have the check `utilparts is not None` however `utilparts` contains the list of partition numbers (eventually empty) which is never None (`[]` is not None) so the condition was always True.
Remove the now useless check and update the message to better reflect the current state of code and intention.