### PR TITLE
CP-47621: Enable ability to set hostname from DHCP

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1395,7 +1395,7 @@ def writeResolvConf(mounts, hn_conf, ns_conf):
         except:
             pass
     else:
-        hostname = 'localhost.localdomain'
+        hostname = ''
 
     # /etc/hostname:
     eh = open('%s/etc/hostname' % mounts['root'], 'w')


### PR DESCRIPTION
According to https://www.freedesktop.org/software/systemd/man/latest/hostname.html Systemd set hostname with following sequence
- kernel parameter, systemd.hostname
- static hostname in /etc/hostname
- transient hostname like DHCP
- localhost at systemd compile time

Set static hostname `localhost.localdomain` in /etc/hostname prevents obtain hostname from DHCP, and all XenRT installed host got localhost.localdomain as the hostname

This commit set empty static hostname to permit DHCP