### PR TITLE
CP-48077: Support python interpreter in shebang of env

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -27,30 +27,22 @@ def run_script(script, stage, *args):
     util.assertDir(constants.SCRIPTS_DIR)
     fd, local_name = tempfile.mkstemp(prefix=stage, dir=constants.SCRIPTS_DIR)
     try:
+        os.close(fd)
         util.fetchFile(script, local_name)
-
-        # check the interpreter
-        fh = os.fdopen(fd)
-        fh.seek(0)
-        line = fh.readline(40)
-        fh.close()
     except:
         raise RuntimeError("Unable to fetch script %s" % script)
-
-    if not line.startswith('#!'):
-        raise RuntimeError("Missing interpreter in %s." % script)
-    interp = line[2:].split()
-    if interp[0] == '/usr/bin/env':
-        if len (interp) < 2 or interp[1] not in ['python3']:
-            raise RuntimeError("Invalid interpreter %s in %s." % (interp[1], script))
-    elif interp[0] not in ['/bin/sh', '/bin/bash', '/usr/bin/python3']:
-        raise RuntimeError("Invalid interpreter %s in %s." % (interp[0], script))
 
     cmd = [local_name]
     cmd.extend(args)
     os.chmod(local_name, stat.S_IRUSR | stat.S_IXUSR)
     os.environ['XS_STAGE'] = stage
-    rc, out, err = util.runCmd2(cmd, with_stdout=True, with_stderr=True)
+
+    try:
+        rc, out, err = util.runCmd2(cmd, with_stdout=True, with_stderr=True)
+    except Exception:
+        # match shell error code for exec failure
+        return 127, "", ""
+
     logger.log("Script returned %d" % rc)
     # keep script, will be collected in support tarball
 


### PR DESCRIPTION
In XS 9 python2 is removed, python is just python3 link. Also remain python interpreter (in shebang) will keep compatibility for scripts, e.g. revert-bootloader.py generated by host-upgrade-plugin for both XS 9 and XS 8.