### PR TITLE
Handle secure boot installations

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1166,8 +1166,14 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
             check_efibootmgr_err(rc, err, install_type, "Failed to remove efi boot entry")
 
     # Then add a new one
+    if os.path.exists(os.path.join(mounts['esp'], 'EFI/xenserver/shimx64.efi')):
+        efi = "EFI/xenserver/shimx64.efi"
+    elif os.path.exists(os.path.join(mounts['esp'], 'EFI/xenserver/grubx64.efi')):
+        efi = "EFI/xenserver/grubx64.efi"
+    else:
+        raise RuntimeError("Failed to find EFI loader")
     rc, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr", "-c",
-                            "-L", branding['product-brand'], "-l", '\\' + "EFI/xenserver/shimx64.efi".replace('/', '\\'),
+                            "-L", branding['product-brand'], "-l", '\\' + efi.replace('/', '\\'),
                             "-d", disk, "-p", str(boot_partnum)], with_stderr=True)
     check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
 

--- a/backend.py
+++ b/backend.py
@@ -1167,7 +1167,7 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
 
     # Then add a new one
     rc, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr", "-c",
-                            "-L", branding['product-brand'], "-l", '\\' + "EFI/xenserver/grubx64.efi".replace('/', '\\'),
+                            "-L", branding['product-brand'], "-l", '\\' + "EFI/xenserver/shimx64.efi".replace('/', '\\'),
                             "-d", disk, "-p", str(boot_partnum)], with_stderr=True)
     check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
 


### PR DESCRIPTION
* CP-45668: Boot shim instead of grub

    This allows Secure Boot to work. It also works for the non-Secure Boot
    path - any verification errors would simply be ignored.

* CP-47745: Detect EFI shim presence dynamically

    Allows code to work with both secure boot or not.