### PR TITLE
CA-391659: Preserve hidden flag updating GPT partitions

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -738,6 +738,11 @@ class DOSPartitionTool(PartitionToolBase):
     ID_DELL_UTILITY = 0xde
     ID_EFI_BOOT = 0xef
 
+    # List of hidden Microsoft partition IDs
+    __HIDDEN_MS_IDS = {
+        0x11, 0x14, 0x16, 0x17, 0x1b, 0x1c, 0x1e, 0x27
+    }
+
     SFDISK = '/sbin/sfdisk'
     partTableType = constants.PARTITION_DOS
 
@@ -825,12 +830,14 @@ class DOSPartitionTool(PartitionToolBase):
                 size = int(matches.group(3))
                 if size != 0: # Treat partitions of size 0 as not present
                     number = self._partitionNumber(matches.group(1))
+                    hidden = idt in self.__HIDDEN_MS_IDS
 
                     partitions[number] = {
                         'start': int(matches.group(2)),
                         'size': size,
                         'id': idt,
-                        'active': active
+                        'active': active,
+                        'hidden': hidden
                         }
         return partitions
 
@@ -958,6 +965,7 @@ class GPTPartitionTool(PartitionToolBase):
         matchHeader    = re.compile('Number\s+Start \(sector\)\s+End \(sector\)\s+Size\s+Code\s+Name')
         matchPartition = re.compile('^\s+(\d+)\s+(\d+)\s+(\d+)\s+([\d.]+\s+\w+)\s+([0-9A-F]{4})(\s+(.*))?$') # num start end sz typecode name
         matchActive    = re.compile('.*\(legacy BIOS bootable\)')
+        matchHidden    = re.compile('.*\(hidden\)')
         matchId        = re.compile('^Partition GUID code: ([0-9A-F\-]+) ')
         matchPartUUID  = re.compile('^Partition unique GUID: ([0-9A-F\-]+)$')
         partitions = {}
@@ -990,6 +998,7 @@ class GPTPartitionTool(PartitionToolBase):
         for number in partitions:
             out = self.cmdWrap([self.SGDISK, '--attributes=%d:show' % number, self.device])
             partitions[number]['active'] = matchActive.match(out) and True or False
+            partitions[number]['hidden'] = matchHidden.match(out) and True or False
             out = self.cmdWrap([self.SGDISK, '--info=%d' % number, self.device])
             for line in out.split('\n'):
                 m = matchId.match(line)
@@ -1065,10 +1074,13 @@ class GPTPartitionTool(PartitionToolBase):
             end    = part['size'] + start - 1
             idt    = part['id']
             active = part['active']
+            hidden = part.get('hidden', False) and idt == self.ID_LINUX
             args = [self.SGDISK, '--set-alignment=1', '--new=%d:%d:%d' % (num,start,end)]
             args += ['--typecode=%d:%s' % (num,self.GUID_to_type_code[idt])]
             if active:
                 args += ['--attributes=%d:set:2' % num] # BIOS bootable flag
+            if hidden:
+                args += ['--attributes=%d:set:62' % num] # hidden flag
             if 'partlabel' in part and part['partlabel']:
                 args += ['--change-name=%d:%s' % (num,part['partlabel'])]
             if 'partuuid' in part:

--- a/restore.py
+++ b/restore.py
@@ -101,6 +101,10 @@ def restoreFromBackup(backup, progress=lambda x: ()):
                 id = new_tool.ID_LINUX_SWAP
             elif part['id'] == tool.ID_LINUX_LVM:
                 id = new_tool.ID_LINUX_LVM
+            elif part['id'] == tool.ID_LINUX:
+                rv, out = util.runCmd2(['blkid', '-s', 'TYPE', '-o', 'value', partitionDevice(tool.device, number)], with_stdout=True)
+                if rv == 0 and 'vfat' in out:
+                    id = 0x1c if part.get('hidden', False) else 0x0c
             # if root make it active
             active = (number == root_partnum)
             new_tool.createPartition(id, tool.partitionSize(number), number, startBytes=tool.partitionStart(number), active=active)

--- a/upgrade.py
+++ b/upgrade.py
@@ -304,12 +304,11 @@ class ThirdGenUpgrader(Upgrader):
                    lambda p: progress_callback(5 + int(p * 0.9)))
 
         # Now that we have freed the end of the disk, convert to GPT
-        util.runCmd2(['sgdisk', '--mbrtogpt', primary_disk])
+        tool = tool.convertToGPT()
 
         progress_callback(97)
 
         # Fix up partition ids to be what the rest of the installer expects
-        tool = PartitionTool(primary_disk)
         tool.partitions[primary_partnum]['id'] = tool.ID_LINUX
         tool.partitions[backup_partnum]['id'] = tool.ID_LINUX
         tool.commit()


### PR DESCRIPTION
Detect hidden flag and save when reading.
Write the flag when partitions are written.

Note that compared to the changes for master this add support for MBR restore (very old XS versions).