### PR TITLE
CA-392333: Do not use host-only fallback initrd

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -994,7 +994,7 @@ def prepFallback(mounts, primary_disk, primary_partnum):
     proc_modules.close()
 
     # Generate /boot/initrd-fallback.img.
-    cmd = ['dracut', '--verbose', '--add-drivers', f'{" ".join(modules)}']
+    cmd = ['dracut', '--verbose', '--add-drivers', ' '.join(modules), '--no-hostonly']
     cmd += ['/boot/initrd-fallback.img', kernel_version]
 
     try:


### PR DESCRIPTION
In case fallback initrd is used potentially the user wants to recover some situation (like some H/W changes) where it would be preferrable to have a more generic initrd with more drivers and software.
This used to be the case before the introduction of dracut usage so restore the old behavior.