### PR TITLE
Backport some changes from master

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -995,7 +995,7 @@ def prepFallback(mounts, primary_disk, primary_partnum):
     proc_modules.close()
 
     # Generate /boot/initrd-fallback.img.
-    cmd = ['dracut', '--verbose', '--add-drivers', " ".join(modules)]
+    cmd = ['dracut', '--verbose', '--add-drivers', ' '.join(modules), '--no-hostonly']
     cmd += ['/boot/initrd-fallback.img', kernel_version]
 
     try:

--- a/backend.py
+++ b/backend.py
@@ -854,43 +854,22 @@ def __mkinitrd(mounts, partition, package, kernel_version, fcoe_interfaces):
                              '/etc/init.d/sm-multipath', action]) != 0:
                 raise RuntimeError("Failed to generate multipath configuration")
 
-        # Run mkinitrd inside dom0 chroot
+        # Run dracut inside dom0 chroot
         output_file = os.path.join("/boot", "initrd-%s.img" % kernel_version)
 
         # default to only including host specific kernel modules in initrd
-        if os.path.isdir(os.path.join(mounts['root'], 'etc/dracut.conf.d')):
-            # disable multipath on root partition
-            try:
-                if not isDeviceMapperNode(partition):
-                    f = open(os.path.join(mounts['root'], 'etc/dracut.conf.d/xs_disable_multipath.conf'), 'w')
-                    f.write('omit_dracutmodules+=" multipath "\n')
-                    f.close()
-            except:
-                pass
-        else:
-            args = ['--theme=/usr/share/splash']
+        # disable multipath on root partition
+        try:
+            if not isDeviceMapperNode(partition):
+                f = open(os.path.join(mounts['root'], 'etc/dracut.conf.d/xs_disable_multipath.conf'), 'w')
+                f.write('omit_dracutmodules+=" multipath "\n')
+                f.close()
+        except:
+            pass
 
-            if isDeviceMapperNode(partition):
-                # [multipath-root]: /etc/fstab specifies the rootdev by LABEL so we need this to make sure mkinitrd
-                # picks up the master device and not the slave
-                args.append('--rootdev='+ partition)
-            else:
-                args.append('--without-multipath')
+        cmd = ['dracut', output_file, kernel_version]
 
-            cmd = ['mkinitrd', '--latch']
-            cmd.extend( args )
-            if util.runCmd2(['chroot', mounts['root']] + cmd) != 0:
-                raise RuntimeError("Failed to latch arguments for initrd.")
-
-        cmd = ['new-kernel-pkg', '--install', '--mkinitrd']
-
-        # Save command used to create initrd in <initrd_filename>.cmd
-        cmd_logfile = os.path.join(mounts['root'], output_file[1:] + '.cmd')
-        cmd_fh = open(cmd_logfile, "w")
-        print >>cmd_fh, ' '.join(cmd + ['"$@"', kernel_version])
-        cmd_fh.close()
-
-        if util.runCmd2(['chroot', mounts['root'], '/bin/sh', output_file + '.cmd']) != 0:
+        if util.runCmd2(['chroot', mounts['root']] + cmd) != 0:
             raise RuntimeError("Failed to create initrd for %s.  This is often due to using an installer that is not the same version of %s as your installation source." % (kernel_version, MY_PRODUCT_BRAND))
 
     finally:
@@ -1016,12 +995,21 @@ def prepFallback(mounts, primary_disk, primary_partnum):
     proc_modules.close()
 
     # Generate /boot/initrd-fallback.img.
-    cmd = ['mkinitrd', '--verbose']
-    for mod in modules:
-        cmd.append('--with=%s' % mod)
+    cmd = ['dracut', '--verbose', '--add-drivers', " ".join(modules)]
     cmd += ['/boot/initrd-fallback.img', kernel_version]
-    if util.runCmd2(['chroot', mounts['root']] + cmd):
-        raise RuntimeError("Failed to generate fallback initrd")
+
+    try:
+        util.bindMount('/sys', os.path.join(mounts['root'], 'sys'))
+        util.bindMount('/dev', os.path.join(mounts['root'], 'dev'))
+        util.bindMount('/proc', os.path.join(mounts['root'], 'proc'))
+
+        if util.runCmd2(['chroot', mounts['root']] + cmd):
+            raise RuntimeError("Failed to generate fallback initrd")
+    finally:
+        util.umount(os.path.join(mounts['root'], 'sys'))
+        util.umount(os.path.join(mounts['root'], 'dev'))
+        util.umount(os.path.join(mounts['root'], 'proc'))
+
 
 def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, serial, boot_serial, host_config, primary_disk, disk_label_suffix, fcoe_interfaces):
     short_version = kernelShortVersion(xen_kernel_version)

--- a/netutil.py
+++ b/netutil.py
@@ -300,11 +300,11 @@ def parse_arg(arg):
     if sd not in ['s', 'd']:
         LOG.warning("'%s' is not valid to distinguish between static/dynamic rules" % (sd,))
         return
+
+    if sd == 's':
+        formulae = static_rules.formulae
     else:
-        if sd == 's':
-            formulae = static_rules.formulae
-        else:
-            formulae = dynamic_rules.formulae
+        formulae = dynamic_rules.formulae
 
     if len(val) < 2:
         LOG.warning("'%s' is not a valid mapping target - Ignoring" % (val,))

--- a/netutil.py
+++ b/netutil.py
@@ -331,7 +331,7 @@ def remap_netdevs(remap_list):
     for cmd in remap_list:
         parse_arg(cmd)
 
-        # Grab the current state from biosdevname
+    # Grab the current state from biosdevname
     current_eths = all_devices_all_names()
     current_state = []
 


### PR DESCRIPTION
1.  CP-47625: Replace mkinitrd with dracut command

    
    mkinitrd command has been deprecated in favor of dracut.
    Update to use dracut to generate initrd.
    
    mkinitrd does not has `--latch` option, even in XS8.
    `/etc/dracut.conf.d` always exists as dracut package installs and owns the folder.
    Also clean the dead code in the else branch.

2.  CA-392333: Do not use host-only fallback initrd

    In case fallback initrd is used potentially the user wants to recover some situation (like some H/W changes) where it would be preferrable to have a more generic initrd with more drivers and software.
    This used to be the case before the introduction of dracut usage so restore the old behavior.

3. Minor space changes