### PR TITLE
setEfiBootEntry: make error messages more useful

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1152,7 +1152,7 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
 
     # First remove existing entries
     rc, out, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr"], True, True)
-    check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
+    check_efibootmgr_err(rc, err, install_type, "Failed to list efi boot entries")
 
     # This list ensures that upgrades from previous versions with different
     # names work, and the current version (so that self-upgrades always work).
@@ -1163,7 +1163,8 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
             bootnum = match.group(1)
             rc, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr",
                                     "--delete-bootnum", "--bootnum", bootnum], with_stderr=True)
-            check_efibootmgr_err(rc, err, install_type, "Failed to remove efi boot entry")
+            check_efibootmgr_err(rc, err, install_type,
+                                 "Failed to remove efi boot entry %r" % (line,))
 
     # Then add a new one
     if os.path.exists(os.path.join(mounts['esp'], 'EFI/xenserver/shimx64.efi')):
@@ -1175,7 +1176,7 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
     rc, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr", "-c",
                             "-L", branding['product-brand'], "-l", '\\' + efi.replace('/', '\\'),
                             "-d", disk, "-p", str(boot_partnum)], with_stderr=True)
-    check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
+    check_efibootmgr_err(rc, err, install_type, "Failed to add new efi boot entry")
 
 def installGrub2(mounts, disk, force):
     if force:


### PR DESCRIPTION
There were 2 identical messages, making it hard to guess from a screenshot which exec caused an error.

While at it, the entry-removal code path can be executed more than once, so give a way to identify which entry is involved when the call fails.