### PR TITLE
CA-392758: Remove Firmware Boot Selected flag check

### DIFF
--- a/diskutil.py
+++ b/diskutil.py
@@ -16,6 +16,7 @@ from snackutil import ButtonChoiceWindowEx
 
 use_mpath = False
 CDROM_GET_CAPABILITY = 0x5331
+IBFT_BLOCK_VALID_FLAG = 1 << 0
 
 def mpath_cli_is_working():
     regex = re.compile("switchgroup")
@@ -615,7 +616,9 @@ def setup_ibft_nics():
             nm = f.read().strip()
         with open(os.path.join(e, 'flags'), 'r') as f:
             flags = int(f.read().strip())
-            assert (flags & 3) == 3
+            if (flags & IBFT_BLOCK_VALID_FLAG) == 0:
+                logger.log("Skipping %s not marked as valid" % (e,))
+                continue
 
         if mac not in mac_map:
             raise RuntimeError('Found mac %s in iBFT but cannot find matching NIC' % mac)


### PR DESCRIPTION
Previously, the installer asserted that both the Block Valid and Firmware Boot Selected flags were set. On some machines, the Firmware Boot Selected flag is not set.

It is not clear why the installer checks this flag. The spec doesn't define its meaning and other software doesn't seem to check it. The only reference I could find was in iPXE where it is unconditionally set. Therefore, simply ignore the flag.

At the same time, instead of hitting an assertion error if the iBFT block is not marked as valid, just skip it. This allows the installation to continue.