### PR TITLE
Some sync master -> release/xs8

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -113,7 +113,7 @@ class Answerfile:
             script = buildURL(stype, getText(node))
             scripts.add_script(stage, script)
 
-        # depreciated formats
+        # deprecated formats
         nodes = getElementsByTagName(self.top_node, ['post-install-script'])
         if len(nodes) == 1:
             stype = getStrAttribute(nodes[0], ['type'], mandatory=False).lower()

--- a/answerfile.py
+++ b/answerfile.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # SPDX-License-Identifier: GPL-2.0-only
 
 """answerfile - parse installation answerfiles"""

--- a/answerfile.py
+++ b/answerfile.py
@@ -181,7 +181,7 @@ class Answerfile:
             disk = normalize_disk(getText(nodes[0]))
             disk = disktools.getMpathMasterOrDisk(disk)
             logger.log("Filtering backup list for disk %s" % disk)
-            backups = filter(lambda x: x.root_disk == disk, backups)
+            backups = [x for x in backups if x.root_disk == disk]
             logger.log("Backup list filtered: %s" % ", ".join(str(b) for b in backups))
 
         if len(backups) > 1:
@@ -236,13 +236,13 @@ class Answerfile:
         results['primary-disk'] = disk
 
         installations = product.findXenSourceProducts()
-        installations = filter(lambda x: x.primary_disk == disk or diskutil.idFromPartition(x.primary_disk) == disk, installations)
+        installations = [x for x in installations if x.primary_disk == disk or diskutil.idFromPartition(x.primary_disk) == disk]
         if len(installations) == 0:
             raise AnswerfileException("Could not locate the installation specified to be reinstalled.")
         elif len(installations) > 1:
             # FIXME non-multipath case?
             logger.log("Warning: multiple paths detected - recommend use of --device_mapper_multipath=yes")
-            logger.log("Warning: selecting 1st path from %s" % str(map(lambda x: x.primary_disk, installations)))
+            logger.log("Warning: selecting 1st path from %s" % str([x.primary_disk for x in installations]))
         results['installation-to-overwrite'] = installations[0]
         return results
 
@@ -366,7 +366,7 @@ class Answerfile:
             else:
                 if_hwaddr = getStrAttribute(interface, ['hwaddr'])
                 if if_hwaddr:
-                    matching_list = filter(lambda x: x.hwaddr == if_hwaddr.lower(), nethw.values())
+                    matching_list = [x for x in list(nethw.values()) if x.hwaddr == if_hwaddr.lower()]
                     if len(matching_list) == 1:
                         if_name = matching_list[0].name
             if not if_name and not if_hwaddr:
@@ -388,7 +388,7 @@ class Answerfile:
         else:
             if_hwaddr = getStrAttribute(node, ['hwaddr'])
             if if_hwaddr:
-                matching_list = filter(lambda x: x.hwaddr == if_hwaddr.lower(), nethw.values())
+                matching_list = [x for x in list(nethw.values()) if x.hwaddr == if_hwaddr.lower()]
                 if len(matching_list) == 1:
                     if_name = matching_list[0].name
         if not if_name and not if_hwaddr:
@@ -440,7 +440,7 @@ class Answerfile:
     def parseNSConfig(self):
         results = {}
         nodes = getElementsByTagName(self.top_node, ['name-server', 'nameserver'])
-        results['manual-nameservers'] = (len(nodes) > 0, map(lambda x: getText(x), nodes))
+        results['manual-nameservers'] = (len(nodes) > 0, [getText(x) for x in nodes])
         nodes = getElementsByTagName(self.top_node, ['hostname'])
         if len(nodes) > 0:
             results['manual-hostname'] = (True, getText(nodes[0]))

--- a/backend.py
+++ b/backend.py
@@ -278,7 +278,7 @@ def executeSequence(sequence, seq_name, answers, ui, cleanup):
             if len(updated_state) > 0:
                 logger.log(
                     "DISPATCH: Updated state: %s" %
-                    str.join("; ", ["%s -> %s" % (v, updated_state[v]) for v in updated_state.keys()])
+                    "; ".join(["%s -> %s" % (k, v) for k, v in updated_state.items()])
                     )
                 for state_item in updated_state:
                     answers[state_item] = updated_state[state_item]
@@ -474,7 +474,7 @@ def rewriteNTPConf(root, ntp_servers):
     lines = ntpsconf.readlines()
     ntpsconf.close()
 
-    lines = filter(lambda x: not x.startswith('server '), lines)
+    lines = [x for x in lines if not x.startswith('server ')]
 
     ntpsconf = open("%s/etc/chrony.conf" % root, 'w')
     for line in lines:
@@ -881,7 +881,7 @@ def getKernelVersion(rootfs_mount):
         return None
 
     try:
-        uname_provides = filter(lambda x: x.startswith('kernel-uname-r'), out.split('\n'))
+        uname_provides = [x for x in out.split('\n') if x.startswith('kernel-uname-r')]
         return uname_provides[0].split('=')[1].strip()
     except:
         pass
@@ -1498,8 +1498,9 @@ def configureNetworking(mounts, admin_iface, admin_bridge, admin_config, hn_conf
     # remove any files that may be present in the filesystem already,
     # particularly those created by kudzu:
     network_scripts = os.listdir(network_scripts_dir)
-    for s in filter(lambda x: x.startswith('ifcfg-'), network_scripts):
-        os.unlink(os.path.join(network_scripts_dir, s))
+    for s in network_scripts:
+        if s.startswith('ifcfg-'):
+            os.unlink(os.path.join(network_scripts_dir, s))
 
     # write the configuration file for the loopback interface
     lo = open(os.path.join(network_scripts_dir, 'ifcfg-lo'), 'w')

--- a/backend.py
+++ b/backend.py
@@ -1214,13 +1214,13 @@ def mountVolumes(primary_disk, boot_partnum, primary_partnum, logs_partnum, clea
     for d in ('proc', 'sys', 'dev'):
         mountdir = os.path.join(mounts['root'], d)
         util.assertDir(mountdir)
-        util.bindMount(f"/{d}", mountdir)
-        new_cleanup.append((f"umount-{mountdir}",  util.umount, mountdir, ))
+        util.bindMount("/%s" % d, mountdir)
+        new_cleanup.append(("umount-%s" % mountdir,  util.umount, mountdir, ))
 
     mountdir = os.path.join(mounts['root'], 'tmp')
     util.assertDir(mountdir)
     util.mount('none', mountdir, None, 'tmpfs')
-    new_cleanup.append((f"umount-{mountdir}",  util.umount, mountdir, ))
+    new_cleanup.append(("umount-%s" % mountdir,  util.umount, mountdir, ))
 
     if target_boot_mode == TARGET_BOOT_MODE_UEFI:
         mounts['esp'] = '/tmp/root/boot/efi'

--- a/backend.py
+++ b/backend.py
@@ -840,43 +840,30 @@ def createDom0DiskFilesystems(install_type, disk, target_boot_mode, boot_partnum
                 mount.unmount()
 
 def __mkinitrd(mounts, partition, package, kernel_version, fcoe_interfaces):
+    if isDeviceMapperNode(partition):
+        # Generate a valid multipath configuration for the initrd
+        action = 'generate-fcoe' if fcoe_interfaces else 'generate-bfs'
+        if util.runCmd2(['chroot', mounts['root'],
+                         '/etc/init.d/sm-multipath', action]) != 0:
+            raise RuntimeError("Failed to generate multipath configuration")
 
+    # Run dracut inside dom0 chroot
+    output_file = os.path.join("/boot", "initrd-%s.img" % kernel_version)
+
+    # default to only including host specific kernel modules in initrd
+    # disable multipath on root partition
     try:
-        util.bindMount('/sys', os.path.join(mounts['root'], 'sys'))
-        util.bindMount('/dev', os.path.join(mounts['root'], 'dev'))
-        util.bindMount('/proc', os.path.join(mounts['root'], 'proc'))
-        util.mount('none', os.path.join(mounts['root'], 'tmp'), None, 'tmpfs')
+        if not isDeviceMapperNode(partition):
+            f = open(os.path.join(mounts['root'], 'etc/dracut.conf.d/xs_disable_multipath.conf'), 'w')
+            f.write('omit_dracutmodules+=" multipath "\n')
+            f.close()
+    except:
+        pass
 
-        if isDeviceMapperNode(partition):
-            # Generate a valid multipath configuration for the initrd
-            action = 'generate-fcoe' if fcoe_interfaces else 'generate-bfs'
-            if util.runCmd2(['chroot', mounts['root'],
-                             '/etc/init.d/sm-multipath', action]) != 0:
-                raise RuntimeError("Failed to generate multipath configuration")
+    cmd = ['dracut', output_file, kernel_version]
 
-        # Run dracut inside dom0 chroot
-        output_file = os.path.join("/boot", "initrd-%s.img" % kernel_version)
-
-        # default to only including host specific kernel modules in initrd
-        # disable multipath on root partition
-        try:
-            if not isDeviceMapperNode(partition):
-                f = open(os.path.join(mounts['root'], 'etc/dracut.conf.d/xs_disable_multipath.conf'), 'w')
-                f.write('omit_dracutmodules+=" multipath "\n')
-                f.close()
-        except:
-            pass
-
-        cmd = ['dracut', output_file, kernel_version]
-
-        if util.runCmd2(['chroot', mounts['root']] + cmd) != 0:
-            raise RuntimeError("Failed to create initrd for %s.  This is often due to using an installer that is not the same version of %s as your installation source." % (kernel_version, MY_PRODUCT_BRAND))
-
-    finally:
-        util.umount(os.path.join(mounts['root'], 'sys'))
-        util.umount(os.path.join(mounts['root'], 'dev'))
-        util.umount(os.path.join(mounts['root'], 'proc'))
-        util.umount(os.path.join(mounts['root'], 'tmp'))
+    if util.runCmd2(['chroot', mounts['root']] + cmd) != 0:
+        raise RuntimeError("Failed to create initrd for %s.  This is often due to using an installer that is not the same version of %s as your installation source." % (kernel_version, MY_PRODUCT_BRAND))
 
 def getXenVersion(rootfs_mount):
     """ Return the xen version by interogating the package version in the chroot """
@@ -998,17 +985,8 @@ def prepFallback(mounts, primary_disk, primary_partnum):
     cmd = ['dracut', '--verbose', '--add-drivers', ' '.join(modules), '--no-hostonly']
     cmd += ['/boot/initrd-fallback.img', kernel_version]
 
-    try:
-        util.bindMount('/sys', os.path.join(mounts['root'], 'sys'))
-        util.bindMount('/dev', os.path.join(mounts['root'], 'dev'))
-        util.bindMount('/proc', os.path.join(mounts['root'], 'proc'))
-
-        if util.runCmd2(['chroot', mounts['root']] + cmd):
-            raise RuntimeError("Failed to generate fallback initrd")
-    finally:
-        util.umount(os.path.join(mounts['root'], 'sys'))
-        util.umount(os.path.join(mounts['root'], 'dev'))
-        util.umount(os.path.join(mounts['root'], 'proc'))
+    if util.runCmd2(['chroot', mounts['root']] + cmd):
+        raise RuntimeError("Failed to generate fallback initrd")
 
 
 def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, serial, boot_serial, host_config, primary_disk, disk_label_suffix, fcoe_interfaces):
@@ -1095,67 +1073,52 @@ def installBootLoader(mounts, disk, boot_partnum, primary_partnum, target_boot_m
                       boot_serial=None, host_config=None, fcoe_interface=None):
     assert(location in [constants.BOOT_LOCATION_MBR, constants.BOOT_LOCATION_PARTITION])
 
-    # prepare extra mounts for installing bootloader:
-    util.bindMount("/dev", "%s/dev" % mounts['root'])
-    util.bindMount("/sys", "%s/sys" % mounts['root'])
-    if target_boot_mode == TARGET_BOOT_MODE_UEFI:
-        util.bindMount("/sys/firmware/efi/efivars", "%s/sys/firmware/efi/efivars" % mounts['root'])
-    util.bindMount("/proc", "%s/proc" % mounts['root'])
+    if host_config:
+        s = serial and {'port': serial.id, 'baud': int(serial.baud)} or None
 
-    try:
-        if host_config:
-            s = serial and {'port': serial.id, 'baud': int(serial.baud)} or None
-
-            if target_boot_mode == TARGET_BOOT_MODE_UEFI:
-                fn = os.path.join(mounts['boot'], "efi/EFI/xenserver/grub.cfg")
-            else:
-                fn = os.path.join(mounts['boot'], "grub/grub.cfg")
-            boot_config = bootloader.Bootloader('grub2', fn,
-                                                timeout=constants.BOOT_MENU_TIMEOUT,
-                                                serial=s, location=location)
-            xen_version = getXenVersion(mounts['root'])
-            if xen_version is None:
-                raise RuntimeError("Unable to determine Xen version.")
-            xen_kernel_version = getKernelVersion(mounts['root'])
-            if not xen_kernel_version:
-                raise RuntimeError("Unable to determine kernel version.")
-            buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config,
-                                serial, boot_serial, host_config, disk,
-                                disk_label_suffix, fcoe_interface)
-            util.assertDir(os.path.dirname(fn))
-            boot_config.commit()
-
-        root_partition = partitionDevice(disk, primary_partnum)
         if target_boot_mode == TARGET_BOOT_MODE_UEFI:
-            if write_boot_entry:
-                setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding)
+            fn = os.path.join(mounts['boot'], "efi/EFI/xenserver/grub.cfg")
         else:
-            if location == constants.BOOT_LOCATION_MBR:
-                installGrub2(mounts, disk, False)
+            fn = os.path.join(mounts['boot'], "grub/grub.cfg")
+        boot_config = bootloader.Bootloader('grub2', fn,
+                                            timeout=constants.BOOT_MENU_TIMEOUT,
+                                            serial=s, location=location)
+        xen_version = getXenVersion(mounts['root'])
+        if xen_version is None:
+            raise RuntimeError("Unable to determine Xen version.")
+        xen_kernel_version = getKernelVersion(mounts['root'])
+        if not xen_kernel_version:
+            raise RuntimeError("Unable to determine kernel version.")
+        buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config,
+                            serial, boot_serial, host_config, disk,
+                            disk_label_suffix, fcoe_interface)
+        util.assertDir(os.path.dirname(fn))
+        boot_config.commit()
+
+    root_partition = partitionDevice(disk, primary_partnum)
+    if target_boot_mode == TARGET_BOOT_MODE_UEFI:
+        if write_boot_entry:
+            setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding)
+    else:
+        if location == constants.BOOT_LOCATION_MBR:
+            installGrub2(mounts, disk, False)
+        else:
+            installGrub2(mounts, root_partition, True)
+
+    if serial:
+        # ensure a getty will run on the serial console
+        old = open("%s/etc/inittab" % mounts['root'], 'r')
+        new = open('/tmp/inittab', 'w')
+
+        for line in old:
+            if line.startswith("s%d:" % serial.id):
+                new.write(re.sub(r'getty \S+ \S+', "getty %s %s" % (serial.dev, serial.baud), line))
             else:
-                installGrub2(mounts, root_partition, True)
+                new.write(line)
 
-        if serial:
-            # ensure a getty will run on the serial console
-            old = open("%s/etc/inittab" % mounts['root'], 'r')
-            new = open('/tmp/inittab', 'w')
-
-            for line in old:
-                if line.startswith("s%d:" % serial.id):
-                    new.write(re.sub(r'getty \S+ \S+', "getty %s %s" % (serial.dev, serial.baud), line))
-                else:
-                    new.write(line)
-
-            old.close()
-            new.close()
-            shutil.move('/tmp/inittab', "%s/etc/inittab" % mounts['root'])
-    finally:
-        # done installing - undo our extra mounts:
-        util.umount("%s/proc" % mounts['root'])
-        if target_boot_mode == TARGET_BOOT_MODE_UEFI:
-            util.umount("%s/sys/firmware/efi/efivars" % mounts['root'])
-        util.umount("%s/sys" % mounts['root'])
-        util.umount("%s/dev" % mounts['root'])
+        old.close()
+        new.close()
+        shutil.move('/tmp/inittab', "%s/etc/inittab" % mounts['root'])
 
 def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
     def check_efibootmgr_err(rc, err, install_type, err_type):
@@ -1248,17 +1211,33 @@ def mountVolumes(primary_disk, boot_partnum, primary_partnum, logs_partnum, clea
     new_cleanup = cleanup + [ ("umount-/tmp/root", util.umount, (mounts['root'], )),
                               ("umount-/tmp/root/mnt",  util.umount, (os.path.join(mounts['root'], 'mnt'), )) ]
 
+    for d in ('proc', 'sys', 'dev'):
+        mountdir = os.path.join(mounts['root'], d)
+        util.assertDir(mountdir)
+        util.bindMount(f"/{d}", mountdir)
+        new_cleanup.append((f"umount-{mountdir}",  util.umount, mountdir, ))
+
+    mountdir = os.path.join(mounts['root'], 'tmp')
+    util.assertDir(mountdir)
+    util.mount('none', mountdir, None, 'tmpfs')
+    new_cleanup.append((f"umount-{mountdir}",  util.umount, mountdir, ))
+
     if target_boot_mode == TARGET_BOOT_MODE_UEFI:
         mounts['esp'] = '/tmp/root/boot/efi'
         bootp = partitionDevice(primary_disk, boot_partnum)
         util.assertDir(os.path.join(mounts['root'], 'boot', 'efi'))
         util.mount(bootp, mounts['esp'])
         new_cleanup.append(("umount-/tmp/root/boot/efi", util.umount, (mounts['esp'], )))
+
+        mountdir = os.path.join(mounts['root'], "sys/firmware/efi/efivars")
+        util.bindMount("/sys/firmware/efi/efivars", mountdir)
+        new_cleanup.append(("umount-/tmp/root/sys/firmware/efi/efivars", util.umount, (mountdir, )))
     if logs_partition:
         mounts['logs'] = os.path.join(mounts['root'], 'var/log')
         util.assertDir(mounts['logs'])
         util.mount(partitionDevice(primary_disk, logs_partnum), mounts['logs'])
         new_cleanup.append(("umount-/tmp/root/var/log", util.umount, (mounts['logs'], )))
+
     return mounts, new_cleanup
 
 def umountVolumes(mounts, cleanup, force=False):
@@ -1271,8 +1250,15 @@ def umountVolumes(mounts, cleanup, force=False):
     util.umount(constants.EXTRA_SCRIPTS_DIR)
     if 'esp' in mounts:
         util.umount(mounts['esp'])
+        util.umount(os.path.join(mounts['root'], "sys/firmware/efi/efivars"))
     if 'logs' in mounts:
         util.umount(mounts['logs'])
+
+    util.umount(os.path.join(mounts['root'], 'tmp'))
+
+    for d in ('proc', 'sys', 'dev'):
+        util.umount(os.path.join(mounts['root'], d))
+
     util.umount(mounts['root'])
     cleanup = filter(filterCleanup, cleanup)
     return cleanup
@@ -1297,9 +1283,6 @@ def prepareSwapfile(mounts, primary_disk, swap_partnum, disk_label_suffix):
     swap_partition = tool.getPartition(swap_partnum)
 
     if swap_partition:
-        util.bindMount("/proc", "%s/proc" % mounts['root'])
-        util.bindMount("/sys", "%s/sys" % mounts['root'])
-        util.bindMount("/dev", "%s/dev" % mounts['root'])
         dev = partitionDevice(primary_disk, swap_partnum)
         while True:
             # The uuid of a swap partition overlaps the same position as the
@@ -1317,19 +1300,12 @@ def prepareSwapfile(mounts, primary_disk, swap_partnum, disk_label_suffix):
             keys = [line.strip().split('=')[0] for line in out.strip().split('\n')]
             if 'ID_FS_AMBIVALENT' not in keys:
                 break
-        util.umount("%s/dev" % mounts['root'])
-        util.umount("%s/proc" % mounts['root'])
-        util.umount("%s/sys" % mounts['root'])
     else:
         util.assertDir("%s/var/swap" % mounts['root'])
         util.runCmd2(['dd', 'if=/dev/zero',
                       'of=%s' % os.path.join(mounts['root'], constants.swap_file.lstrip('/')),
                       'bs=1024', 'count=%d' % (constants.swap_file_size * 1024)])
-        util.bindMount("/proc", "%s/proc" % mounts['root'])
-        util.bindMount("/sys", "%s/sys" % mounts['root'])
         util.runCmd2(['chroot', mounts['root'], 'mkswap', constants.swap_file])
-        util.umount("%s/proc" % mounts['root'])
-        util.umount("%s/sys" % mounts['root'])
 
 def writeFstab(mounts, target_boot_mode, primary_disk, logs_partnum, swap_partnum, disk_label_suffix):
 

--- a/cpiofile.py
+++ b/cpiofile.py
@@ -1,4 +1,3 @@
-#! /usr/bin/python
 # -*- coding: utf-8 -*-
 
 # SPDX-License-Identifier: MIT

--- a/cpiofile.py
+++ b/cpiofile.py
@@ -1794,10 +1794,9 @@ class CpioFileCompat:
                 m.file_size = m.size
                 m.date_time = time.gmtime(m.mtime)[:6]
     def namelist(self):
-        return map(lambda m: m.name, self.infolist())
+        return [m.name for m in self.infolist()]
     def infolist(self):
-        return filter(lambda m: m.isreg(),
-                      self.cpiofile.getmembers())
+        return [m for m in self.cpiofile.getmembers() if m.isreg()]
     def printdir(self):
         self.cpiofile.list()
     def testzip(self):

--- a/disktools.py
+++ b/disktools.py
@@ -1141,7 +1141,7 @@ def PartitionTool(device, partitionType=None):
 def destroyPartnodes(dev):
     # Destroy partition nodes for a device-mapper device
     dmnodes = [ '/dev/mapper/%s' % f for f in os.listdir('/dev/mapper') ]
-    partitions = filter(lambda dmnode: re.match(dev + r'p?\d+$', dmnode), dmnodes)
+    partitions = [dmnode for dmnode in dmnodes if re.match(dev + r'p?\d+$', dmnode)]
     for partition in partitions:
         # the obvious way to do this is to use "kpartx -d" but that's broken!
         rv = util.runCmd2(['dmsetup', 'remove', partition])
@@ -1183,7 +1183,7 @@ def getDeviceMapperMaj():
     global cached_DM_maj
     if not cached_DM_maj:
         try:
-            line = filter(lambda x: x.endswith('device-mapper\n'), open('/proc/devices').readlines())
+            line = [x for x in open('/proc/devices').readlines() if x.endswith('device-mapper\n')]
             cached_DM_maj = int(line[0].split()[0])
         except:
             pass
@@ -1198,8 +1198,7 @@ def isDeviceMapperNode(dev):
 def getSysfsDir(dev):
     major, minor = getMajMin(dev)
     parts = open("/proc/partitions")
-    partlines = map(lambda x: re.sub(" +", " ", x).strip(),
-                    parts.readlines())
+    partlines = [re.sub(" +", " ", x).strip() for x in parts.readlines()]
     parts.close()
     # parse it:
     disks = []
@@ -1238,7 +1237,7 @@ def getDeviceSlaves(disk):
     major, minor = getMajMin(disk)
     rv, out = util.runCmd2(['sh','-c','ls -d1 /sys/block/*/holders/*/dev'],with_stdout=True)
     lines = out.strip().split('\n')
-    lines = filter(lambda x: x != '', lines)
+    lines = [x for x in lines if x != '']
     for f in lines:
         _, _, _, dev, _, _, _ = f.split('/')
         __major, __minor = map(int, open(f).read().split(':'))

--- a/disktools.py
+++ b/disktools.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # SPDX-License-Identifier: GPL-2.0-only
 
 import constants

--- a/generalui.py
+++ b/generalui.py
@@ -10,7 +10,7 @@ def getTimeZoneRegions():
     lines = tzf.readlines()
     tzf.close()
 
-    lines = map(lambda x: x.strip('\n').split('/'), lines)
+    lines = [x.strip('\n').split('/') for x in lines]
 
     regions = []
     for zone in lines:
@@ -24,7 +24,7 @@ def getTimeZoneCities(desired_region):
     lines = tzf.readlines()
     tzf.close()
 
-    lines = map(lambda x: x.strip('\n').split('/'), lines)
+    lines = [x.strip('\n').split('/') for x in lines]
 
     cities = []
     for zone in lines:
@@ -39,7 +39,7 @@ def getKeymaps():
     lines = kbdfile.readlines()
     kbdfile.close()
 
-    lines = map(lambda x: x.strip('\n').split('/'), lines)
+    lines = [x.strip('\n').split('/') for x in lines]
 
     keymaps = []
     for keymap in lines:

--- a/hardware.py
+++ b/hardware.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # SPDX-License-Identifier: GPL-2.0-only
 
 import constants

--- a/init
+++ b/init
@@ -72,7 +72,7 @@ def configureNetworking(ui, device, config):
             iface_to_start.append(device)
     else:
         # MAC address
-        matching_list = filter(lambda x: x.hwaddr == device, nethw.values())
+        matching_list = [x for x in nethw.values() if x.hwaddr == device]
         if len(matching_list) == 1:
             devname = matching_list[0].name
             iface_to_start.append(devname)

--- a/netutil.py
+++ b/netutil.py
@@ -105,7 +105,7 @@ def ipaddr(interface):
     rc, out = util.runCmd2(['ip', 'addr', 'show', interface], with_stdout=True)
     if rc != 0:
         return None
-    inets = filter(lambda x: 'inet ' in x, out.split("\n"))
+    inets = [x for x in out.split("\n") if 'inet ' in x]
     if len(inets) == 1:
         m = re.search(r'inet (\S+)/', inets[0])
         if m:
@@ -117,7 +117,7 @@ def interfaceUp(interface):
     rc, out = util.runCmd2(['ip', 'addr', 'show', interface], with_stdout=True)
     if rc != 0:
         return False
-    inets = filter(lambda x: x.startswith("    inet "), out.split("\n"))
+    inets = [x for x in out.split("\n") if x.startswith("    inet ")]
     return len(inets) == 1
 
 # work out if a link is up:
@@ -140,7 +140,7 @@ def setAllLinksUp():
         if nif not in diskutil.ibft_reserved_nics:
             subprocs.append(subprocess.Popen(['ip', 'link', 'set', nif, 'up'], close_fds=True))
 
-    while None in map(lambda x: x.poll(), subprocs):
+    while None in [x.poll() for x in subprocs]:
         time.sleep(1)
 
 def networkingUp():

--- a/product.py
+++ b/product.py
@@ -67,7 +67,7 @@ class ExistingInstallation:
             if os.path.exists(self.join_state_path('etc/firstboot.d/state')):
                 firstboot_files = [ f for f in os.listdir(self.join_state_path('etc/firstboot.d')) \
                                     if f[0].isdigit() and os.stat(self.join_state_path('etc/firstboot.d', f))[stat.ST_MODE] & stat.S_IXUSR ]
-                missing_state_files = filter(lambda x: not os.path.exists(self.join_state_path('etc/firstboot.d/state', x)), firstboot_files)
+                missing_state_files = [x for x in firstboot_files if not os.path.exists(self.join_state_path('etc/firstboot.d/state', x))]
 
                 result = (len(missing_state_files) == 0)
                 if not result:
@@ -384,10 +384,10 @@ class ExistingInstallation:
             xen_args = boot_config.menu[boot_config.default].getHypervisorArgs()
 
             #   - cpuid_mask
-            results['host-config']['xen-cpuid-masks'] = filter(lambda x: x.startswith('cpuid_mask'), xen_args)
+            results['host-config']['xen-cpuid-masks'] = [x for x in xen_args if x.startswith('cpuid_mask')]
 
             #   - dom0_mem
-            dom0_mem_arg = filter(lambda x: x.startswith('dom0_mem'), xen_args)
+            dom0_mem_arg = [x for x in xen_args if x.startswith('dom0_mem')]
             (dom0_mem, dom0_mem_min, dom0_mem_max) = xcp.dom0.parse_mem(dom0_mem_arg[0])
             if dom0_mem:
                 results['host-config']['dom0-mem'] = dom0_mem // (1024*1024)

--- a/repository.py
+++ b/repository.py
@@ -144,7 +144,7 @@ class YumRepository(Repository):
         primaryfp.close()
 
         # Filter using only sha256 checksum
-        sha256_checksums = filter(lambda x: x.getAttribute("type") == "sha256", package_checksums)
+        sha256_checksums = [x for x in package_checksums if x.getAttribute("type") == "sha256"]
 
         # After the filter, the list of checksums will have the same size
         # of the list of names
@@ -737,8 +737,7 @@ def findRepositoriesOnMedia(drivers=False):
         static_devices.extend(map(os.path.basename, glob.glob('/sys/block/' + pattern)))
 
     removable_devices = diskutil.getRemovableDeviceList()
-    removable_devices = filter(lambda x: not x.startswith('fd'),
-                               removable_devices)
+    removable_devices = [x for x in removable_devices if not x.startswith('fd')]
 
     parent_devices = []
     partitions = []

--- a/restore.py
+++ b/restore.py
@@ -157,8 +157,7 @@ def restoreFromBackup(backup, progress=lambda x: ()):
                 efi_mounted = True
 
             # copy files from the backup partition to the restore partition:
-            objs = filter(lambda x: x not in ['lost+found', '.xen-backup-partition', '.xen-gpt.bin'],
-                          os.listdir(backup_fs.mount_point))
+            objs = [x for x in os.listdir(backup_fs.mount_point) if x not in ['lost+found', '.xen-backup-partition', '.xen-gpt.bin']]
             for i in range(len(objs)):
                 obj = objs[i]
                 logger.log("Restoring subtree %s..." % obj)

--- a/restore.py
+++ b/restore.py
@@ -202,21 +202,28 @@ def restoreFromBackup(backup, progress=lambda x: ()):
 
             mounts = {'root': dest_fs.mount_point, 'boot': os.path.join(dest_fs.mount_point, 'boot')}
 
+            # prepare extra mounts for installing bootloader:
+            util.bindMount("/dev", "%s/dev" % dest_fs.mount_point)
+            util.bindMount("/sys", "%s/sys" % dest_fs.mount_point)
+            util.bindMount("/proc", "%s/proc" % dest_fs.mount_point)
+
             # restore boot loader
-            with util.ChrootMounts(dest_fs.mount_point):
-                if boot_config.src_fmt == 'grub2':
-                    if efi_boot:
-                        branding = util.readKeyValueFile(os.path.join(backup_fs.mount_point, constants.INVENTORY_FILE))
-                        branding['product-brand'] = branding['PRODUCT_BRAND']
-                        backend.setEfiBootEntry(mounts, disk_device, boot_partnum, constants.INSTALL_TYPE_RESTORE, branding)
-                    else:
-                        if location == constants.BOOT_LOCATION_MBR:
-                            backend.installGrub2(mounts, disk_device, False)
-                        else:
-                            backend.installGrub2(mounts, restore_partition, True)
+            if boot_config.src_fmt == 'grub2':
+                if efi_boot:
+                    branding = util.readKeyValueFile(os.path.join(backup_fs.mount_point, constants.INVENTORY_FILE))
+                    branding['product-brand'] = branding['PRODUCT_BRAND']
+                    backend.setEfiBootEntry(mounts, disk_device, boot_partnum, constants.INSTALL_TYPE_RESTORE, branding)
                 else:
-                    backend.installExtLinux(mounts, disk_device, probePartitioningScheme(disk_device), location)
+                    if location == constants.BOOT_LOCATION_MBR:
+                        backend.installGrub2(mounts, disk_device, False)
+                    else:
+                        backend.installGrub2(mounts, restore_partition, True)
+            else:
+                backend.installExtLinux(mounts, disk_device, probePartitioningScheme(disk_device), location)
         finally:
+            util.umount("%s/proc" % dest_fs.mount_point)
+            util.umount("%s/sys" % dest_fs.mount_point)
+            util.umount("%s/dev" % dest_fs.mount_point)
             if efi_mounted:
                 util.umount(esp)
             dest_fs.unmount()

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -1040,7 +1040,7 @@ def get_timezone_city(answers):
         tui.screen,
         "Select Time Zone",
         "Please select the city or area that the managed host is in (press a letter to jump to that place in the list):",
-        map(lambda x: x.replace('_', ' '), entries),
+        [x.replace('_', ' ') for x in entries],
         ['Ok', 'Back'], height=8, scroll=1, default=default, help='gettz')
 
     if button == 'back': return LEFT_BACKWARDS
@@ -1121,7 +1121,7 @@ def get_ntp_servers(answers):
 
     if button == 'back': return LEFT_BACKWARDS
 
-    servers = filter(lambda x: x != "", [ntp1_field.value(), ntp2_field.value(), ntp3_field.value()])
+    servers = [ntp_field.value() for ntp_field in (ntp1_field, ntp2_field, ntp3_field) if ntp_field.value() != ""]
     if len(servers) == 0:
         ButtonChoiceWindow(tui.screen,
                             "NTP Configuration",

--- a/tui/network.py
+++ b/tui/network.py
@@ -171,7 +171,7 @@ def select_netif(text, conf, offer_existing=False, default=None):
             snackutil.TableDialog(tui.screen, "Interface Details", *table)
         else:
             netifs_all = netutil.getNetifList(include_vlan=True)
-            details = map(lambda x: (x, netutil.ipaddr(x)), filter(netutil.interfaceUp, netifs_all))
+            details = [(x, netutil.ipaddr(x)) for x in list(filter(netutil.interfaceUp, netifs_all))]
             snackutil.TableDialog(tui.screen, "Networking Details", *details)
         tui.screen.popHelpLine()
         return True

--- a/tui/repo.py
+++ b/tui/repo.py
@@ -206,7 +206,7 @@ def get_source_location(answers, require_base_rep):
         return get_nfs_location(answers, require_base_rep)
 
 def confirm_load_repo(answers, label, installed_repos):
-    cap_label = ' '.join(map(lambda a: a.capitalize(), label.split()))
+    cap_label = ' '.join([a.capitalize() for a in label.split()])
     if 'source-media' in answers and 'source-address' in answers:
         media = answers['source-media']
         address = answers['source-address']
@@ -227,7 +227,7 @@ def confirm_load_repo(answers, label, installed_repos):
         return LEFT_BACKWARDS
 
     if label != 'driver':
-        repos = filter(lambda r: r.identifier() != constants.MAIN_REPOSITORY_NAME, repos)
+        repos = [r for r in repos if r.identifier() != constants.MAIN_REPOSITORY_NAME]
 
     if len(repos) == 0:
         ButtonChoiceWindow(
@@ -285,7 +285,7 @@ def confirm_load_repo(answers, label, installed_repos):
 
 # verify the installation source?
 def verify_source(answers, label, require_base_repo):
-    cap_label = ' '.join(map(lambda a: a.capitalize(), label.split()))
+    cap_label = ' '.join([a.capitalize() for a in label.split()])
     if 'source-media' in answers and 'source-address' in answers:
         media = answers['source-media']
         address = answers['source-address']
@@ -337,7 +337,7 @@ def verify_source(answers, label, require_base_repo):
     return RIGHT_FORWARDS
 
 def interactive_source_verification(repos, label):
-    cap_label = ' '.join(map(lambda a: a.capitalize(), label.split()))
+    cap_label = ' '.join([a.capitalize() for a in label.split()])
     errors = []
     pd = tui.progress.initProgressDialog(
         "Verifying %s Source" % cap_label, "Initializing...",

--- a/util.py
+++ b/util.py
@@ -213,26 +213,6 @@ class TempMount:
         if os.path.isdir(self.mount_point):
             os.rmdir(self.mount_point)
 
-class ChrootMounts:
-    def __init__(self, root_dir):
-        self.root_dir = root_dir
-
-    def __enter__(self):
-        root_dir = self.root_dir
-        bindMount('/sys', os.path.join(root_dir, 'sys'))
-        bindMount('/dev', os.path.join(root_dir, 'dev'))
-        bindMount('/proc', os.path.join(root_dir, 'proc'))
-        bindMount('/run', os.path.join(root_dir, 'run'))
-        mount('none', os.path.join(root_dir, 'tmp'), None, 'tmpfs')
-
-    def __exit__(self, type, value, traceback):
-        root_dir = self.root_dir
-        umount(os.path.join(root_dir, 'tmp'))
-        umount(os.path.join(root_dir, 'run'))
-        umount(os.path.join(root_dir, 'proc'))
-        umount(os.path.join(root_dir, 'dev'))
-        umount(os.path.join(root_dir, 'sys'))
-
 ###
 # fetching of remote files
 

--- a/util.py
+++ b/util.py
@@ -324,8 +324,7 @@ def readKeyValueFile(filename, allowed_keys=None, strip_quotes=True):
 
     # remove lines that do not contain allowed keys
     if allowed_keys:
-        lines = filter(lambda x: True in [x.startswith(y) for y in allowed_keys],
-                       lines)
+        lines = [x for x in lines if True in [x.startswith(y) for y in allowed_keys]]
 
     defs = [ (l[:l.find("=")], l[(l.find("=") + 1):]) for l in lines ]
 

--- a/xelogging.py
+++ b/xelogging.py
@@ -38,8 +38,8 @@ def collectLogs(dst, tarball_dir=None):
             shutil.copy("/tmp/install-log", dst)
         if os.path.exists(constants.SCRIPTS_DIR):
             os.system("cp -r "+constants.SCRIPTS_DIR+" %s/" % dst)
-    logs = filter(lambda x: x.endswith('-log') or x == 'answerfile' or
-                  x.startswith(os.path.basename(constants.SCRIPTS_DIR)), os.listdir(dst))
+    logs = [x for x in os.listdir(dst) if x.endswith('-log') or x == 'answerfile' or
+                  x.startswith(os.path.basename(constants.SCRIPTS_DIR))]
     logs = " ".join(logs)
 
     if os.path.exists(tarball_dir):


### PR DESCRIPTION
This PR takes some changes from master branch.
The difference look smaller ignoring space changes.

1. Revert "Reuse context manager to mount directory for chroot executed commands"
    This reverts commit 8390720f335cd6b6cfe4d4b86c1663bf9c664ea4.
    Superseded by next commit on master
2. CA-389863: Speed up installation with newer systemd
    Each time, RPM execs a process during the install, it closes all open file descriptors up to the hard limit. The default hard limit for systemd services with newer systemd increased from 4096 to 524288. This caused a regression in installation time as dnf spends almost all the time setting the CLOEXEC bit on non-existent file descriptors.
    Fix this by ensuring that /dev, /proc, and /sys are bind mounted into the root before starting installation. That way, RPM can close only the open file descriptors rather than all of the possible fds. This decreases the dnf phase of installation on my test host from 900 seconds to 100 seconds.
    As a side effect, it silences various complaints about these filesystems not being mounted, simplifies the code, and avoids pointless mount/unmount cycles.
3. Compatibility for Python 2
    Use syntax compatible with both Python 2 and 3.
    Needed to make installer work on XS8 after previous commit.

Also there are some commits trying to minimize the difference between Python 2 and Python 3.