### PR TITLE
Port some commits from master to release/xs8

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1145,8 +1145,14 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
                                  "Failed to remove efi boot entry %r" % (line,))
 
     # Then add a new one
+    if os.path.exists(os.path.join(mounts['esp'], 'EFI/xenserver/shimx64.efi')):
+        efi = "EFI/xenserver/shimx64.efi"
+    elif os.path.exists(os.path.join(mounts['esp'], 'EFI/xenserver/grubx64.efi')):
+        efi = "EFI/xenserver/grubx64.efi"
+    else:
+        raise RuntimeError("Failed to find EFI loader")
     rc, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr", "-c",
-                            "-L", branding['product-brand'], "-l", '\\' + "EFI/xenserver/shimx64.efi".replace('/', '\\'),
+                            "-L", branding['product-brand'], "-l", '\\' + efi.replace('/', '\\'),
                             "-d", disk, "-p", str(boot_partnum)], with_stderr=True)
     check_efibootmgr_err(rc, err, install_type, "Failed to add new efi boot entry")
 

--- a/backend.py
+++ b/backend.py
@@ -1146,7 +1146,7 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
 
     # Then add a new one
     rc, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/efibootmgr", "-c",
-                            "-L", branding['product-brand'], "-l", '\\' + "EFI/xenserver/grubx64.efi".replace('/', '\\'),
+                            "-L", branding['product-brand'], "-l", '\\' + "EFI/xenserver/shimx64.efi".replace('/', '\\'),
                             "-d", disk, "-p", str(boot_partnum)], with_stderr=True)
     check_efibootmgr_err(rc, err, install_type, "Failed to add new efi boot entry")
 

--- a/constants.py
+++ b/constants.py
@@ -52,25 +52,19 @@ NETWORK_BACKEND_VSWITCH_ALT = "vswitch"
 
 # error strings:
 def error_string(error, logname, with_hd):
-    (
-        ERROR_STRING_UNKNOWN_ERROR_WITH_HD,
-        ERROR_STRING_UNKNOWN_ERROR_WITHOUT_HD,
-        ERROR_STRING_KNOWN_ERROR
-    ) = range(3)
-
-    ERROR_STRINGS = {
-        ERROR_STRING_UNKNOWN_ERROR_WITH_HD: "An unrecoverable error has occurred.  The details of the error can be found in the log file, which has been written to /tmp/%s (and /root/%s on your hard disk if possible).\n\nPlease refer to your user guide or contact a Technical Support Representative for more details.",
-        ERROR_STRING_UNKNOWN_ERROR_WITHOUT_HD: "An unrecoverable error has occurred.  The details of the error can be found in the log file, which has been written to /tmp/%s.\n\nPlease refer to your user guide or contact a Technical Support Representative for more details.",
-        ERROR_STRING_KNOWN_ERROR: "An unrecoverable error has occurred.  The error was:\n\n%s\n\nPlease refer to your user guide, or contact a Technical Support Representative, for further details."
-        }
-
+    error = error.rstrip()
     if error == "":
+        err = "The details of the error can be found in the log file, which has been written to /tmp/%s" % logname
         if with_hd:
-            return ERROR_STRINGS[ERROR_STRING_UNKNOWN_ERROR_WITH_HD] % (logname, logname)
-        else:
-            return ERROR_STRINGS[ERROR_STRING_UNKNOWN_ERROR_WITHOUT_HD] % logname
+            err += " (and /root/%s on your hard disk if possible)" % logname
     else:
-        return ERROR_STRINGS[ERROR_STRING_KNOWN_ERROR] % error
+        err = "The error was:\n\n%s" % error
+
+    if err[-1:] != '.':
+        err += '.'
+
+    return ('An unrecoverable error has occurred.  ' + err +
+        '\n\nPlease refer to your user guide or contact a Technical Support Representative for more details.')
 
 # minimum hardware specs:
 # memory checks should be done against MIN_SYSTEM_RAM_MB since libxc

--- a/disktools.py
+++ b/disktools.py
@@ -594,9 +594,7 @@ class PartitionToolBase:
         partitions = [None] + [part for num, part in sorted(self.partitions.iteritems(), key=lambda item: item[1]['start'])]
 
         if startBytes is None:
-            if len(partitions) == 0:
-                startSector = self.sectorFirstUsable
-            elif order:
+            if order:
                 if order < 1:
                     raise Exception("Order cannot be less than 1")
                 elif order == 1:

--- a/disktools.py
+++ b/disktools.py
@@ -961,8 +961,10 @@ class GPTPartitionTool(PartitionToolBase):
     def readDiskDetails(self):
         self.sectorSize        = int(self.cmdWrap(['blockdev', '--getss', self.device]))
         self.sectorExtent      = int(self.cmdWrap(['blockdev', '--getsize64', self.device])) // self.sectorSize
-        self.sectorFirstUsable = 34
-        self.sectorLastUsable  = self.sectorExtent - 34
+        # size depends on GPT entries (should be 128), their size (128 bytes) and sector size
+        # first sector is MBR, second GPT header
+        self.sectorFirstUsable = 2 - (-128*128 // self.sectorSize)
+        self.sectorLastUsable  = self.sectorExtent - self.sectorFirstUsable
         self.sectorAlignment   = 2 ** 20 // self.sectorSize
 
     def partitionTable(self):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import sys
+import os.path
+sys.path.append(os.path.join(os.path.abspath(os.path.dirname(__file__)), '..'))
+
+import unittest
+import constants
+
+class TestErrorString(unittest.TestCase):
+    def check(self, error, logname, with_hd, expected):
+        got = constants.error_string(error, logname, with_hd)
+        self.assertEqual(got, expected)
+
+    def test_hello(self):
+        self.check('hello', 'LOGFILE', True, '''An unrecoverable error has occurred.  The error was:
+
+hello.
+
+Please refer to your user guide or contact a Technical Support Representative for more details.''')
+
+    def test_with_dot(self):
+        self.check('hello.', 'LOGFILE', True, '''An unrecoverable error has occurred.  The error was:
+
+hello.
+
+Please refer to your user guide or contact a Technical Support Representative for more details.''')
+
+    def test_empty(self):
+        self.check('', 'LOGFILE', True, '''An unrecoverable error has occurred.  The details of the error can be found in the log file, which has been written to /tmp/LOGFILE (and /root/LOGFILE on your hard disk if possible).
+
+Please refer to your user guide or contact a Technical Support Representative for more details.''')
+
+    def test_empty_without_hd(self):
+        self.check('', 'LOGFILE', False, '''An unrecoverable error has occurred.  The details of the error can be found in the log file, which has been written to /tmp/LOGFILE.
+
+Please refer to your user guide or contact a Technical Support Representative for more details.''')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1. CP-45668: Boot shim instead of grub
    This allows Secure Boot to work. It also works for the non-Secure Boot path - any verification errors would simply be ignored.

2. CP-47745: Detect EFI shim presence dynamically
    Allows code to work with both secure boot or not.

3. Rewrite `error_string` function
    Avoids duplication of part of the error messages.
    Do not declare enumeration or dictionary, just use strings.
    Make sure error is terminated with a dot.

4. Add a test for `error_string` function

5. Remove useless check
    partitions has always at least one elements (a dummy None one) so it can't have a length of 0.

6. Fix sector computation for disk with sector size not 512
    The size of GPT used sector depends on sector size.
    Specifically it takes 1 sector for the header and others for partition table.
    Tested with emulated disk using Qemu and 4KB disk.

7. Use blockdev command to read sector size
    `sfdisk` is always returning 512.
    Device mapper code assume 512.
    Use always `blockdev --getss` to get the correct value.