### PR TITLE
Reduce difference between master and release/xs8 branches

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1431,7 +1431,8 @@ def setRootPassword(mounts, root_pwd):
         cmd = ["/usr/sbin/chroot", mounts["root"], "chpasswd", "-e"]
         pipe = subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                      stdout=subprocess.PIPE,
-                                     close_fds=True)
+                                     close_fds=True,
+                                     universal_newlines=True)
         pipe.communicate('root:%s\n' % root_password)
         assert pipe.wait() == 0
     else:
@@ -1439,7 +1440,8 @@ def setRootPassword(mounts, root_pwd):
         pipe = subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
-                                     close_fds=True)
+                                     close_fds=True,
+                                     universal_newlines=True)
         pipe.communicate(root_password + "\n")
         assert pipe.wait() == 0
 

--- a/backend.py
+++ b/backend.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+from __future__ import print_function
+
 import os
 import os.path
 import stat
@@ -733,11 +735,11 @@ def prepareStorageRepositories(mounts, primary_disk, storage_partnum, guest_disk
 
     links = map(lambda x: diskutil.idFromPartition(x) or x, partitions)
     fd = open(os.path.join(mounts['root'], constants.FIRSTBOOT_DATA_DIR, 'default-storage.conf'), 'w')
-    print >>fd, "XSPARTITIONS='%s'" % str.join(" ", links)
-    print >>fd, "XSTYPE='%s'" % sr_type
+    print("XSPARTITIONS='%s'" % str.join(" ", links), file=fd)
+    print("XSTYPE='%s'" % sr_type, file=fd)
     # Legacy names
-    print >>fd, "PARTITIONS='%s'" % str.join(" ", links)
-    print >>fd, "TYPE='%s'" % sr_type
+    print("PARTITIONS='%s'" % str.join(" ", links), file=fd)
+    print("TYPE='%s'" % sr_type, file=fd)
     fd.close()
 
 def make_free_space(mount, required):
@@ -1467,24 +1469,24 @@ def configureNetworking(mounts, admin_iface, admin_bridge, admin_config, hn_conf
     mgmt_conf_file = os.path.join(mounts['root'], constants.FIRSTBOOT_DATA_DIR, 'management.conf')
     if not os.path.exists(mgmt_conf_file):
         mc = open(mgmt_conf_file, 'w')
-        print >>mc, "LABEL='%s'" % admin_iface
-        print >>mc, "MODE='%s'" % netinterface.NetInterface.getModeStr(admin_config.mode)
+        print("LABEL='%s'" % admin_iface, file=mc)
+        print("MODE='%s'" % netinterface.NetInterface.getModeStr(admin_config.mode), file=mc)
         if admin_config.mode == netinterface.NetInterface.Static:
-            print >>mc, "IP='%s'" % admin_config.ipaddr
-            print >>mc, "NETMASK='%s'" % admin_config.netmask
+            print("IP='%s'" % admin_config.ipaddr, file=mc)
+            print("NETMASK='%s'" % admin_config.netmask, file=mc)
             if admin_config.gateway:
-                print >>mc, "GATEWAY='%s'" % admin_config.gateway
+                print("GATEWAY='%s'" % admin_config.gateway, file=mc)
             if manual_nameservers:
-                print >>mc, "DNS='%s'" % (','.join(nameservers),)
+                print("DNS='%s'" % (','.join(nameservers),), file=mc)
             if domain:
-                print >>mc, "DOMAIN='%s'" % domain
-        print >>mc, "MODEV6='%s'" % netinterface.NetInterface.getModeStr(admin_config.modev6)
+                print("DOMAIN='%s'" % domain, file=mc)
+        print("MODEV6='%s'" % netinterface.NetInterface.getModeStr(admin_config.modev6), file=mc)
         if admin_config.modev6 == netinterface.NetInterface.Static:
-            print >>mc, "IPv6='%s'" % admin_config.ipv6addr
+            print("IPv6='%s'" % admin_config.ipv6addr, file=mc)
             if admin_config.ipv6_gateway:
-                print >>mc, "IPv6_GATEWAY='%s'" % admin_config.ipv6_gateway
+                print("IPv6_GATEWAY='%s'" % admin_config.ipv6_gateway, file=mc)
         if admin_config.vlan:
-            print >>mc, "VLAN='%d'" % admin_config.vlan
+            print("VLAN='%d'" % admin_config.vlan, file=mc)
         mc.close()
 
     if network_backend == constants.NETWORK_BACKEND_VSWITCH:

--- a/backend.py
+++ b/backend.py
@@ -704,7 +704,7 @@ def writeGuestDiskPartitions(primary_disk, guest_disks):
             assert gd[:5] == '/dev/'
 
             tool = PartitionTool(gd, constants.PARTITION_GPT)
-            tool.deletePartitions(tool.partitions.keys())
+            tool.deletePartitions(list(tool.partitions.keys()))
             tool.commit(log=True)
 
 
@@ -1268,7 +1268,7 @@ def umountVolumes(mounts, cleanup, force=False):
         util.umount(os.path.join(mounts['root'], d))
 
     util.umount(mounts['root'])
-    cleanup = filter(filterCleanup, cleanup)
+    cleanup = list(filter(filterCleanup, cleanup))
     return cleanup
 
 ##########

--- a/backend.py
+++ b/backend.py
@@ -615,7 +615,7 @@ def writeDom0DiskPartitions(disk, target_boot_mode, boot_partnum, primary_partnu
         raise RuntimeError("The disk %s is smaller than %dGB." % (disk, constants.min_primary_disk_size))
 
     tool = PartitionTool(disk, constants.PARTITION_GPT)
-    for num, part in tool.iteritems():
+    for num, part in tool.items():
         if num >= primary_partnum:
             tool.deletePartition(num)
 
@@ -1345,7 +1345,7 @@ def enableAgent(mounts, network_backend, services):
 
     # Enable/disable miscellaneous services
     actMap = {'enabled': 'enable', 'disabled': 'disable'}
-    for (service, state) in services.iteritems():
+    for (service, state) in services.items():
         action = 'disable' if constants.CC_PREPARATIONS and state is None else actMap.get(state)
         if action:
             util.runCmd2(['chroot', mounts['root'], 'systemctl', action, service + '.service'])

--- a/backend.py
+++ b/backend.py
@@ -733,7 +733,7 @@ def prepareStorageRepositories(mounts, primary_disk, storage_partnum, guest_disk
 
     # write a config file for the prepare-storage firstboot script:
 
-    links = map(lambda x: diskutil.idFromPartition(x) or x, partitions)
+    links = [diskutil.idFromPartition(x) or x for x in partitions]
     fd = open(os.path.join(mounts['root'], constants.FIRSTBOOT_DATA_DIR, 'default-storage.conf'), 'w')
     print("XSPARTITIONS='%s'" % str.join(" ", links), file=fd)
     print("XSTYPE='%s'" % sr_type, file=fd)

--- a/cpiofile.py
+++ b/cpiofile.py
@@ -32,6 +32,8 @@
    Derived from Lars Gustäbel's tarfile.py
 """
 
+from __future__ import print_function
+
 version     = "0.1"
 __author__  = "Simon Rowe"
 __credits__ = "Lars Gustäbel"
@@ -1206,17 +1208,17 @@ class CpioFile(object):
 
         for cpioinfo in self:
             if verbose:
-                print filemode(cpioinfo.mode),
-                print "%d/%d" % (cpioinfo.uid, cpioinfo.gid),
+                print(filemode(cpioinfo.mode), end=' ')
+                print("%d/%d" % (cpioinfo.uid, cpioinfo.gid), end=' ')
                 if cpioinfo.ischr() or cpioinfo.isblk():
-                    print "%10s" % ("%d,%d" \
-                                    % (cpioinfo.devmajor, cpioinfo.devminor)),
+                    print("%10s" % ("%d,%d" \
+                                    % (cpioinfo.devmajor, cpioinfo.devminor)), end=' ')
                 else:
-                    print "%10d" % cpioinfo.size,
-                print "%d-%02d-%02d %02d:%02d:%02d" \
-                      % time.localtime(cpioinfo.mtime)[:6],
+                    print("%10d" % cpioinfo.size, end=' ')
+                print("%d-%02d-%02d %02d:%02d:%02d" \
+                      % time.localtime(cpioinfo.mtime)[:6], end=' ')
 
-            print cpioinfo.name
+            print(cpioinfo.name)
 
     def add(self, name, arcname=None, recursive=True):
         """Add the file `name' to the archive. `name' may be any type of file
@@ -1731,7 +1733,7 @@ class CpioFile(object):
         """Write debugging output to sys.stderr.
         """
         if level <= self.debug:
-            print >> sys.stderr, msg
+            print(msg, file=sys.stderr)
 # class CpioFile
 
 class CpioIter:

--- a/cpiofile.py
+++ b/cpiofile.py
@@ -115,7 +115,7 @@ def copyfileobj(src, dst, length=None):
 
     BUFSIZE = 16 * 1024
     blocks, remainder = divmod(length, BUFSIZE)
-    for b in xrange(blocks):
+    for b in range(blocks):
         buf = src.read(BUFSIZE)
         if len(buf) < BUFSIZE:
             raise IOError("end of file reached")
@@ -381,7 +381,7 @@ class _Stream:
         """
         if pos - self.pos >= 0:
             blocks, remainder = divmod(pos - self.pos, self.bufsize)
-            for i in xrange(blocks):
+            for i in range(blocks):
                 self.read(self.bufsize)
             self.read(remainder)
         else:
@@ -1698,7 +1698,7 @@ class CpioFile(object):
         else:
             end = members.index(cpioinfo)
 
-        for i in xrange(end - 1, -1, -1):
+        for i in range(end - 1, -1, -1):
             if name == members[i].name:
                 return members[i]
 

--- a/disktools.py
+++ b/disktools.py
@@ -900,7 +900,7 @@ class DOSPartitionTool(PartitionToolBase):
             rc, err = util.runCmd2([self.SFDISK, '-LVquS', self.device], with_stderr=True)
             if rc == 1:
                 lines = err.split('\n')
-                if len(filter(lambda x : x != '' and not x.endswith('extends past end of disk'), lines)) != 0:
+                if len([x for x in lines if x != '' and not x.endswith('extends past end of disk')]) != 0:
                     raise Exception(err)
             elif rc != 0:
                 raise Exception(err)

--- a/disktools.py
+++ b/disktools.py
@@ -834,7 +834,7 @@ class DOSPartitionTool(PartitionToolBase):
         input = 'unit: sectors\n\n'
 
         # sfdisk doesn't allow us to skip partitions, so invent lines for empty slot
-        for number in range(1, 1+max([1]+table.keys())):
+        for number in range(1, 1+max([1]+list(table.keys()))):
             partition = table.get(number, {
                 'start': 0,
                 'size': 0,

--- a/disktools.py
+++ b/disktools.py
@@ -871,6 +871,7 @@ class DOSPartitionTool(PartitionToolBase):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             close_fds=True,
+            universal_newlines=True,
             )
         output = process.communicate(input)
         if log:

--- a/disktools.py
+++ b/disktools.py
@@ -458,7 +458,7 @@ class LVMTool:
             totalExtents += sum([ move.size for move in moveList ])
         extentsSoFar = 0
 
-        for device, moveList in sorted(self.moveLists.iteritems()):
+        for device, moveList in sorted(self.moveLists.items()):
             thisSize = sum([ move.size for move in moveList ])
             callback = lambda percent : (progress_callback( 5 + (98 - 5) * (extentsSoFar + thisSize * percent / 100) / totalExtents) )
             self.executeMoves(callback, device, moveList)
@@ -591,7 +591,7 @@ class PartitionToolBase:
         if newNumber in self.partitions:
             raise Exception('Partition '+str(newNumber)+' already exists')
 
-        partitions = [None] + [part for num, part in sorted(self.partitions.iteritems(), key=lambda item: item[1]['start'])]
+        partitions = [None] + [part for num, part in sorted(self.partitions.items(), key=lambda item: item[1]['start'])]
 
         if startBytes is None:
             if order:
@@ -692,13 +692,13 @@ class PartitionToolBase:
         self.partitions[number]['active'] = activeFlag
 
     def inactivateDisk(self):
-        for number, partition in self.partitions.iteritems():
+        for number, partition in self.partitions.items():
             if partition['active']:
                 self.setActiveFlag(False, number)
 
-    def iteritems(self):
+    def items(self):
         # sorted() creates a new list, so you can delete partitions whilst iterating
-        for number, partition in sorted(self.partitions.iteritems()):
+        for number, partition in sorted(self.partitions.items()):
             yield number, partition
 
     def commit(self, dryrun=False, log=False):
@@ -713,14 +713,14 @@ class PartitionToolBase:
         output += "Sector last usable  : "+str(self.sectorLastUsable)+"\n"
         output += "Sector first usable : "+str(self.sectorFirstUsable)+"\n"
         output += "Partition size and start addresses in sectors:\n"
-        for number, partition in sorted(self.origPartitions.iteritems()):
+        for number, partition in sorted(self.origPartitions.items()):
             output += "Old partition "+str(number)+":"
-            for k, v in sorted(partition.iteritems()):
+            for k, v in sorted(partition.items()):
                 output += ' '+k+'='+((k == 'id') and hex(v) or str(v))
             output += "\n"
-        for number, partition in sorted(self.partitions.iteritems()):
+        for number, partition in sorted(self.partitions.items()):
             output += "New partition "+str(number)+":"
-            for k, v in sorted(partition.iteritems()):
+            for k, v in sorted(partition.items()):
                 output += ' '+k+'='+((k == 'id') and hex(v) or str(v))
             output += "\n"
         logger.log(output)
@@ -916,7 +916,7 @@ class DOSPartitionTool(PartitionToolBase):
 
         # Copy hidden attribute on MS partitions
         hidden_args = []
-        for num, part in self.partitions.iteritems():
+        for num, part in self.partitions.items():
             if part['id'] in self.__HIDDEN_MS_IDS and gpt_tool.partitions[num]['id'] == gpt_tool.ID_LINUX:
                 hidden_args.append('--attributes=%d:set:62' % num)
                 gpt_tool.partitions[num]['hidden'] = True
@@ -1019,7 +1019,7 @@ class GPTPartitionTool(PartitionToolBase):
         return partitions
 
     def commitActivePartitiontoDisk(self, partnum):
-        for num, part in self.iteritems():
+        for num, part in self.items():
             if num == partnum:
                 self.cmdWrap([self.SGDISK, '--attributes=%d:set:2' % num, self.device]) # BIOS bootable flag set
             else:

--- a/disktools.py
+++ b/disktools.py
@@ -1019,11 +1019,15 @@ class GPTPartitionTool(PartitionToolBase):
         return partitions
 
     def commitActivePartitiontoDisk(self, partnum):
+        args = []
         for num, part in self.items():
             if num == partnum:
-                self.cmdWrap([self.SGDISK, '--attributes=%d:set:2' % num, self.device]) # BIOS bootable flag set
+                args += ['--attributes=%d:set:2' % num] # BIOS bootable flag set
             else:
-                self.cmdWrap([self.SGDISK, '--attributes=%d:clear:2' % num, self.device]) # BIOS bootable flag clear
+                args += ['--attributes=%d:clear:2' % num] # BIOS bootable flag clear
+
+        if args:
+            self.cmdWrap([self.SGDISK] + args + [self.device])
 
         self.waitForDeviceNodes()
 
@@ -1071,25 +1075,26 @@ class GPTPartitionTool(PartitionToolBase):
 
         # Ensure that we write out in on-disk order to prevent conflicts when
         # partition sizes get rounded.
+        args = [self.SGDISK, '--set-alignment=1']
         items = sorted(table.items(), key=lambda item: item[1]['start'])
         for num,part in items:
             start  = part['start']
             end    = part['size'] + start - 1
             idt    = part['id']
             active = part['active']
-            hidden = part.get('hidden', False) and idt == self.ID_LINUX
-            args = [self.SGDISK, '--set-alignment=1', '--new=%d:%d:%d' % (num,start,end)]
+            hidden = part.get('hidden', False)
+            args += ['--new=%d:%d:%d' % (num,start,end)]
             args += ['--typecode=%d:%s' % (num,self.GUID_to_type_code[idt])]
             if active:
                 args += ['--attributes=%d:set:2' % num] # BIOS bootable flag
-            if hidden:
+            if hidden and idt == self.ID_LINUX:
                 args += ['--attributes=%d:set:62' % num] # hidden flag
             if 'partlabel' in part and part['partlabel']:
                 args += ['--change-name=%d:%s' % (num,part['partlabel'])]
             if 'partuuid' in part:
                 args += ['--partition-guid=%d:%s' % (num,part['partuuid'])]
-            args += [self.device]
-            self.cmdWrap(args)
+        args += [self.device]
+        self.cmdWrap(args)
 
         if isDeviceMapperNode(self.device):
             # Create partitions using device mapper

--- a/diskutil.py
+++ b/diskutil.py
@@ -106,7 +106,7 @@ disk_nodes += [ (202, x * 16) for x in range(16) ]
 
 # /dev/cciss : c[0-7]d[0-15]: Compaq Next Generation Drive Array
 # /dev/ida   : c[0-7]d[0-15]: Compaq Intelligent Drive Array
-for major in range(72, 80) + range(104, 112):
+for major in list(range(72, 80)) + list(range(104, 112)):
     disk_nodes += [ (major, x * 16) for x in range(16) ]
 
 # /dev/rd    : c[0-7]d[0-31]: Mylex DAC960 PCI RAID controller

--- a/diskutil.py
+++ b/diskutil.py
@@ -515,7 +515,7 @@ def probeDisk(device):
     possible_srs = []
 
     tool = PartitionTool(device)
-    for num, part in tool.iteritems():
+    for num, part in tool.items():
         label = None
         part_device = tool._partitionDevice(num)
 

--- a/fcoeutil.py
+++ b/fcoeutil.py
@@ -86,7 +86,7 @@ def start_fcoe(interfaces):
     # of seconds for FCoE to stabilize.
     time.sleep(30)
     util.runCmd2(util.udevsettleCmd())
-    for interface, status in result.iteritems():
+    for interface, status in result.items():
         if status == 'OK':
             logger.log(get_luns_on_intf(interface))
 
@@ -124,7 +124,7 @@ def get_fcoe_capable_ifaces(check_lun):
             outdata = outstr.split(':')
             return "Successful" in outdata[1]
 
-    for nic, conf in nics.iteritems():
+    for nic, conf in nics.items():
         if get_dcb_capablity(nic):
             if check_lun and len(get_luns_on_intf(nic)) > 0:
                 continue
@@ -231,7 +231,7 @@ def get_luns_on_intf(interface):
 
     for vlan in vlans:
         if vlan in fcoedisks:
-            for rport, val in fcoedisks[vlan].iteritems():
+            for rport, val in fcoedisks[vlan].items():
                 for lun in val['luns'].values():
                     lluns.append(lun['device'])
 

--- a/init
+++ b/init
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: GPL-2.0-only
 
+from __future__ import print_function
+
 import sys
 import os
 import os.path
@@ -99,7 +101,7 @@ def main(args):
     try:
         tty = os.path.basename(os.readlink('/proc/self/fd/0'))
         pidfile = open('/var/run/installer-%s.pid' % tty, 'w')
-        print >>pidfile, os.getpid()
+        print(os.getpid(), file=pidfile)
         pidfile.close()
     except:
         pass
@@ -164,7 +166,7 @@ def main(args):
     if ui:
         # switch to ISO 8859-1 mode so line drawing characters work as expected on
         # vt100 terminals.
-        print "\033%@"
+        print("\033%@")
 
         logger.log("Starting 'init' user interface on %s" % tty)
         ui.init_ui()

--- a/init
+++ b/init
@@ -68,7 +68,7 @@ def configureNetworking(ui, device, config):
 
     iface_to_start = []
     if device == 'all':
-        iface_to_start.extend(netcfg.keys())
+        iface_to_start.extend(list(netcfg.keys()))
     elif device.startswith('eth'):
         if device in nethw:
             iface_to_start.append(device)

--- a/init_constants.py
+++ b/init_constants.py
@@ -9,4 +9,4 @@ OPERATION_REBOOT = -1
     OPERATION_UPGRADE,
     OPERATION_LOAD_DRIVER,
     OPERATION_RESTORE,
-) = range(5)
+) = list(range(5))

--- a/install.py
+++ b/install.py
@@ -302,7 +302,7 @@ Please remove any local media from the drive, and press Enter to reboot.""")
             backend.prettyLogAnswers(results)
         except Exception as e:
             # Don't let logging exceptions prevent subsequent actions
-            print 'Logging failed: '+str(e)
+            print('Logging failed: '+str(e))
 
         # exit with failure status:
         status = constants.EXIT_ERROR

--- a/netutil.py
+++ b/netutil.py
@@ -220,7 +220,7 @@ def valid_ip_addr(addr):
 def network(ipaddr, netmask):
     ip = list(map(int,ipaddr.split('.',3)))
     nm = list(map(int,netmask.split('.',3)))
-    nw = map(lambda i: ip[i] & nm[i], range(4))
+    nw = [ip[i] & nm[i] for i in range(4)]
     return ".".join(map(str,nw))
 
 def prefix2netmask(mask):

--- a/netutil.py
+++ b/netutil.py
@@ -162,7 +162,7 @@ def getPCIInfo(interface):
         info = output.strip('\n')
 
     cur_if = None
-    pipe = subprocess.Popen(['biosdevname', '-d'], bufsize=1, stdout=subprocess.PIPE)
+    pipe = subprocess.Popen(['biosdevname', '-d'], bufsize=1, stdout=subprocess.PIPE, universal_newlines=True)
     for line in pipe.stdout:
         l = line.strip('\n')
         if l.startswith('Kernel name'):
@@ -234,7 +234,7 @@ class NetDevices:
         self.netdev = []
         details = {}
 
-        pipe = subprocess.Popen(['biosdevname', '-d'], bufsize=1, stdout=subprocess.PIPE)
+        pipe = subprocess.Popen(['biosdevname', '-d'], bufsize=1, stdout=subprocess.PIPE, universal_newlines=True)
         for line in pipe.stdout:
             l = line.strip('\n')
             if len(l) == 0:

--- a/netutil.py
+++ b/netutil.py
@@ -225,7 +225,7 @@ def network(ipaddr, netmask):
 
 def prefix2netmask(mask):
     bits = 0
-    for i in xrange(32-mask, 32):
+    for i in range(32-mask, 32):
         bits |= (1 << i)
     return inet_ntoa(pack('>I', bits))
 

--- a/netutil.py
+++ b/netutil.py
@@ -218,8 +218,8 @@ def valid_ip_addr(addr):
     return True
 
 def network(ipaddr, netmask):
-    ip = map(int,ipaddr.split('.',3))
-    nm = map(int,netmask.split('.',3))
+    ip = list(map(int,ipaddr.split('.',3)))
+    nm = list(map(int,netmask.split('.',3)))
     nw = map(lambda i: ip[i] & nm[i], range(4))
     return ".".join(map(str,nw))
 
@@ -397,7 +397,7 @@ def remap_netdevs(remap_list):
     def macpci_as_list(x):
         return [str(x.mac), str(x.pci), x.tname]
 
-    new_lastboot = map(macpci_as_list, current_state)
+    new_lastboot = list(map(macpci_as_list, current_state))
     dynamic_rules.lastboot = new_lastboot
 
     LOG.info("All done ordering the network devices")

--- a/repository.py
+++ b/repository.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+from __future__ import print_function
+
 import os
 import os.path
 import glob
@@ -333,8 +335,8 @@ gpgkey=file://%s
         self._conffile = os.path.join(confdir, 'xs_disable.conf')
         os.makedirs(confdir, 0o775)
         with open(self._conffile, 'w') as f:
-            print >> f, 'echo Skipping initrd creation during host installation'
-            print >> f, 'exit 0'
+            print('echo Skipping initrd creation during host installation', file=f)
+            print('exit 0', file=f)
 
     def enableInitrdCreation(self):
         os.unlink(self._conffile)

--- a/tui/fcoe.py
+++ b/tui/fcoe.py
@@ -98,10 +98,10 @@ def select_fcoe_ifaces(answers):
     logger.log("fcoe result %s" % str(result))
     tui.progress.clearModelessDialog()
 
-    fail = {k: v for k, v in result.iteritems() if v != 'OK'}
+    fail = {k: v for k, v in result.items() if v != 'OK'}
     if len(fail.keys()) > 0:
         # Report any errors
-        err_text = '\n'.join(map(lambda (x, y): "%s %s" % (x, y), fail.iteritems()))
+        err_text = '\n'.join(map(lambda (x, y): "%s %s" % (x, y), fail.items()))
         text = TextboxReflowed(60, "The following errors occured while discovering FCoE disks.")
         errs = Textbox(30, 6, err_text, scroll=len(fail.keys()) > 6)
         buttons = ButtonBar(tui.screen, [('Ok', 'ok')])

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -216,7 +216,7 @@ def get_admin_interface(answers):
 
 def get_admin_interface_configuration(answers):
     if 'net-admin-interface' not in answers:
-        answers['net-admin-interface'] = answers['network-hardware'].keys()[0]
+        answers['net-admin-interface'] = list(answers['network-hardware'].keys())[0]
     nic = answers['network-hardware'][answers['net-admin-interface']]
 
     defaults = None
@@ -667,7 +667,7 @@ def select_guest_disks(answers):
     # Also, since the DM nodes are multipathed SANs it doesn't make sense to include them
     # in the "Local" SR.
     allowed_in_local_sr = lambda dev: (dev == answers['primary-disk']) or (not isDeviceMapperNode(dev))
-    diskEntries = filter(allowed_in_local_sr, diskEntries)
+    diskEntries = list(filter(allowed_in_local_sr, diskEntries))
 
     if len(diskEntries) == 0 or constants.CC_PREPARATIONS:
         answers['guest-disks'] = []
@@ -777,7 +777,7 @@ def confirm_installation(answers):
         label = "Confirm Installation"
         text1 = "We have collected all the information required to install %s. " % MY_PRODUCT_BRAND
         if answers['install-type'] == constants.INSTALL_TYPE_FRESH:
-            disks = map(diskutil.getHumanDiskName, answers['guest-disks'])
+            disks = list(map(diskutil.getHumanDiskName, answers['guest-disks']))
             if diskutil.getHumanDiskName(answers['primary-disk']) not in disks:
                 disks.append(diskutil.getHumanDiskName(answers['primary-disk']))
             disks.sort()
@@ -894,7 +894,7 @@ def get_name_service_configuration(answers):
         elif 'runtime-iface-configuration' in answers:
             all_dhcp, netdict = answers['runtime-iface-configuration']
             if not all_dhcp and isinstance(netdict, dict):
-                nameservers = netdict.values()[0].dns
+                nameservers = list(netdict.values())[0].dns
 
         if isinstance(nameservers, list) and id < len(nameservers):
             return nameservers[id]

--- a/tui/network.py
+++ b/tui/network.py
@@ -139,7 +139,7 @@ def select_netif(text, conf, offer_existing=False, default=None):
     netutil.scanConfiguration() output to be used.
     """
 
-    netifs = conf.keys()
+    netifs = list(conf.keys())
     netifs.sort(lambda l, r: int(l[3:]) - int(r[3:]))
 
     if default not in netifs:
@@ -267,7 +267,7 @@ def requireNetworking(answers, defaults=None, msg=None, keys=['net-admin-interfa
                 uicontroller.Step(specify_configuration, args=[None, def_conf]) ]
     else:
         text = "%s Setup needs network access to continue.\n\nHow should networking be configured at this time?" % (version.PRODUCT_BRAND or version.PLATFORM_NAME)
-        conf_dict['interface'] = nethw.keys()[0]
+        conf_dict['interface'] = list(nethw.keys())[0]
         seq = [ uicontroller.Step(specify_configuration, args=[text, def_conf]) ]
     direction = uicontroller.runSequence(seq, conf_dict)
 

--- a/tui/repo.py
+++ b/tui/repo.py
@@ -29,7 +29,7 @@ def selectDefault(key, entries):
     REPOCHK_NO_BASE_REPO,
     REPOCHK_PLATFORM_VERSION_MISMATCH,
     REPOCHK_NO_ERRORS
-) = range(5)
+) = list(range(5))
 
 def check_repo_def(definition, require_base_repo):
     """ Check that the repository source definition gives access to suitable
@@ -236,7 +236,7 @@ def confirm_load_repo(answers, label, installed_repos):
             ['Back'])
         return LEFT_BACKWARDS
 
-    USE, VERIFY, BACK = range(3)
+    USE, VERIFY, BACK = list(range(3))
     default_button = BACK
     if len(repos) == 1:
         text = TextboxReflowed(54, "The following %s was found:\n\n" % label)
@@ -293,7 +293,7 @@ def verify_source(answers, label, require_base_repo):
         media = 'local'
         address = ''
     done = False
-    SKIP, VERIFY = range(2)
+    SKIP, VERIFY = list(range(2))
     entries = [ ("Skip verification", SKIP),
                 ("Verify %s source" % label, VERIFY), ]
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+from __future__ import print_function
+
 import os
 import re
 import shutil
@@ -601,7 +603,7 @@ class ThirdGenUpgrader(Upgrader):
         f.close()
 
         state = open(os.path.join(mounts['root'], constants.FIRSTBOOT_DATA_DIR, 'host.conf'), 'w')
-        print >>state, "UPGRADE=true"
+        print("UPGRADE=true", file=state)
         state.close()
 
         # The existence of the static-rules.conf is used to detect upgrade from Boston or newer

--- a/upgrade.py
+++ b/upgrade.py
@@ -660,6 +660,5 @@ class UpgraderList(list):
 __upgraders__ = UpgraderList([ThirdGenUpgrader, InCloudSphereUpgrader])
 
 def filter_for_upgradeable_products(installed_products):
-    upgradeable_products = filter(lambda p: p.isUpgradeable() and upgradeAvailable(p),
-        installed_products)
+    upgradeable_products = [p for p in installed_products if p.isUpgradeable() and upgradeAvailable(p)]
     return upgradeable_products

--- a/util.py
+++ b/util.py
@@ -122,7 +122,7 @@ def pidof(name):
         except:
             return False
     pids = filter(is_pid, os.listdir('/proc'))
-    pids = filter(has_name, pids)
+    pids = list(filter(has_name, pids))
     return pids
 
 def mount(dev, mountpoint, options=None, fstype=None):

--- a/util.py
+++ b/util.py
@@ -61,6 +61,7 @@ def runCmd2(command, with_stdout=False, with_stderr=False, inputtext=None):
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
                                shell=isinstance(command, str),
+                               universal_newlines=True,
                                close_fds=True)
 
         # We could poll stdout/stderr for commands outputing large amounts


### PR DESCRIPTION
Use different ways to reduce differences between the 2 branches
1. Make print statements Python 2/3 compatible
    Add parenthesis where possible, use `import __future__` to get full source compatibility in Python 2.

2. Use universal_newlines option for Popen
     The options is supported by Python 2 too, not only Python 3

3. Force list in some cases
    Python 3 tends to use generators which in some cases changes the results, or simply you want to have a list instead.
    Python 3 code already has this change, in Python 2 is mainly a no-operation so copy to Python 2 to reduce source differences.

4. Use range and items to increase Python 2/3 compatibility
    The difference between xrange vs range and items vs iteritems in Python 2 mainly changes list with iterators.
    This could improve memory usage and performance in case of larger containers but this increase the difference between Python 2 and Python 3 source code.
    We don't have huge containers so use Python 3 syntax to reduce source code difference.

5. Use list comprehension if possible
    Syntax is compatible between Python 2 and Python 3.

6. Repartition with one single command
   This commit was merged recently in master branch
