### PR TITLE
CA-376240: Check signature of driver disks/supp packs during host installation

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -377,6 +377,7 @@ class UpdateYumRepository(YumRepositoryWithInfo):
             self._controlpkg = dom.documentElement.getAttribute('control')
             self._identifier = dom.documentElement.getAttribute('name-label')
             self._targets = [self._controlpkg, 'update-' + self._identifier]
+            self._key = dom.documentElement.getAttribute('key')
         except Exception as e:
             accessor.finish()
             logger.logException(e)
@@ -387,6 +388,13 @@ class UpdateYumRepository(YumRepositoryWithInfo):
 
     def name(self):
         return self._identifier
+
+    def _repo_config(self):
+        return """
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/%s
+""" % self._key
+
 
 class DriverUpdateYumRepository(UpdateYumRepository):
     """Represents a Yum repository containing packages and associated meta data for a driver disk."""


### PR DESCRIPTION
The GPG key is specified in the updates.xml of the supplemental pack to install.
The key will already be present on the host as keys are installed as part of the main installation before the supp packs are installed.
During test deployments any test/dev keys must be loaded before the supp packs/driver disks are installed.

Tested on XenServer 8