### PR TITLE
CA-392916: Create directory for mount= option

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 import constants
+import errno
 import re, subprocess, types, os, time
 from pprint import pprint
 from copy import copy, deepcopy
@@ -1285,6 +1286,12 @@ class DeviceMounter:
             return "Mount(%s, %s, %s, %s)" % (self.dev, self.mountpoint, self.fstype, self.options)
 
         def mount(self):
+            try:
+                os.makedirs(self.mountpoint, mode=0o755)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+
             util.mount(self.dev, self.mountpoint, self.options, self.fstype)
 
         def umount(self):


### PR DESCRIPTION
This fixes a regression introduced by commit 99bec34bfc "CA-391027: Mount devices specified by mount= only when needed", code was always attempting to create the directory before mounting.

The call to `os.makedirs` do not use `exists_ok` option for compatibility with Python 2 code.