### PR TITLE
CA-392935: Release device if partition does not need to be resized

### DIFF
--- a/shrinklvm.py
+++ b/shrinklvm.py
@@ -971,6 +971,7 @@ def shrink_lvm(drive, partno, start_space, end_space, progress_callback):
 
     if not regions:
         logger.log('LVM partition does not need to be shrunk')
+        lvm.close()
         return
 
     # If we're shrinking the start by an amount that is not a multiple of the extent size


### PR DESCRIPTION
Trying to shrink LVM partition if we detect that we don't need to do anything we returned without closing lvm object. As lvm object is retained by VG objects contained in the same lvm object, the release (and the close of the internal "file" attribute) happens when a full garbage collection is done (due to the circular reference).
Close manually to release the device as soon as possible making the following device partitioning succeed.