### PR TITLE
CP-49195: Allows to preserve first partition from MBR layout

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -565,10 +565,9 @@ def partitionTargetDisk(disk, existing, preserve_first_partition, create_sr_part
 
     tool = PartitionTool(disk)
 
-    # Cannot preserve partition for legacy DOS partition table.
+    # Cannot preserve utility partition for legacy DOS partition table.
     if tool.partTableType == constants.PARTITION_DOS :
-        if preserve_first_partition == 'true' or (
-                preserve_first_partition == constants.PRESERVE_IF_UTILITY and tool.utilityPartitions()):
+        if preserve_first_partition == constants.PRESERVE_IF_UTILITY and tool.utilityPartitions():
             raise RuntimeError("Preserving initial partition on DOS unsupported")
 
     # Preserve any utility partitions unless user told us to zap 'em


### PR DESCRIPTION
This allows to install a clean XenServer 8 using NetScaler platform machines based on MBR partution layout.