### PR TITLE
CP-49641: Ignore errors mounting/unmounting explicit mount points

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -1357,11 +1357,17 @@ class DeviceMounter:
 
     def mount(self):
         for m in self.mounts:
-            m.mount()
+            try:
+                m.mount()
+            except Exception as e:
+                logger.logException(e)
 
     def __umount(self):
         for m in self.mounts:
-            m.umount()
+            try:
+                m.umount()
+            except Exception as e:
+                logger.logException(e)
 
     def __enter__(self):
         self.mount()


### PR DESCRIPTION
Code to handle `mount=` options were rewritten adding additional error checking.
However this resulted in a feature regression as this poor error handling is used as a "try next if fails" behavior allowing to specify multiple devices for the same mount point. For instance specifying `mount=/dev/sda2:/mnt mount=/dev/disk/by-label/DEMO:/mnt` for the same `/mnt` mount point the two possible device names were attempted. So instead of giving error log the error and continue to restore the old behavior.