### PR TITLE
Use xl command instead of small inline python

### DIFF
--- a/startup/preinit
+++ b/startup/preinit
@@ -21,7 +21,7 @@ IFS="
 "
 
 xen_commandline() {
-  python -c "import xen.lowlevel.xc as xc; print xc.xc().xeninfo()['xen_commandline']"
+  xl info xen_commandline
 }
 
 # Spaces separate arguments except for spaces enclosed by a pair of single or


### PR DESCRIPTION
Shorter and not requiring changes between Python 2 and 3.

This patch is already in `master`, porting to `release/xs8`.