### PR TITLE
CA-392317: Make sure kernel is up to date using Gdisk

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -194,3 +194,7 @@ try:
             SR_TYPE_LARGE_BLOCK = value
 except IOError:
     pass
+
+# Error partitioning disk as in use
+PARTITIONING_ERROR = \
+	'The disk appears to be in use and partition changes cannot be applied. Reboot and repeat the installation'


### PR DESCRIPTION
The behavior of `gdisk` if disk layout cannot be updated is different from `fdisk`; the former write a warning while the latter returns with error.
This results in possible corruptions during the installation. Check and report the warning as error.

Note that this is mainly a backport from `master` branch (2 additional hunks for `convertToGPT` function which is not present in `master`).