### PR TITLE
Handle corrupted GPT data with MBR disks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ install:
 	        install.py \
 	        netinterface.py \
 	        netutil.py \
+	        ppexpect.py \
 	        product.py \
 	        report.py \
 	        repository.py \

--- a/disktools.py
+++ b/disktools.py
@@ -966,7 +966,7 @@ class GPTPartitionTool(PartitionToolBase):
 
     def partitionTable(self):
         cmd = [self.SGDISK, '--print', self.device]
-        rv, out, err = util.runCmd2(cmd, True, True)
+        rv, out, _ = util.runCmd2(cmd, True, True)
         if rv != 0:
             logger.log('Invalid or corrupt partition table found on disk %s. Skipping...' % self.device)
             self.waitForDeviceNodes()

--- a/ppexpect.py
+++ b/ppexpect.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+# Poor Python Expect.
+# Simplified expect to run a process
+
+import errno
+import fcntl
+import os
+import select
+import subprocess
+import sys
+import time
+
+__all__ = ['Process', 'TimeoutError']
+
+def set_nonblocking(fd):
+    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+
+if sys.version_info[0] < 3:
+    class TimeoutError(OSError):
+        def __init__(self):
+            super(TimeoutError, self).__init__(errno.ETIMEDOUT, None)
+else:
+    TimeoutError = TimeoutError
+
+class Process:
+    def __init__(self, cmd):
+        process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+            universal_newlines=True,
+            )
+        set_nonblocking(process.stdout.fileno())
+
+        self.process = process
+
+    def __del__(self):
+        self.close()
+
+    def write(self, msg):
+        stdin = self.process.stdin
+        stdin.write(msg)
+        stdin.flush()
+
+    def expect(self, msg, timeout=1.0):
+        data = b''
+        deadline = time.time() + timeout
+        while True:
+            if type(msg) == str:
+                found = msg in data.decode()
+            else:
+                found = msg.match(data.decode())
+            if found:
+                return found
+
+            data += self.__readDeadline(deadline)
+
+    def __readDeadline(self, deadline):
+        fd = self.process.stdout.fileno()
+        now = time.time()
+        if now > deadline:
+            raise TimeoutError()
+        select.select([fd], [], [], deadline - now)
+        return self.__readFd(fd)
+
+    @staticmethod
+    def __readFd(fd):
+        try:
+            return os.read(fd, 1024 * 16)
+        except OSError as ex:
+            if ex.errno != errno.EAGAIN:
+                raise
+        return b''
+
+    def close(self):
+        if not self.process:
+            return None
+        process = self.process
+        self.process = None
+        process.stdin.close()
+        res = process.wait()
+        process.stdout.close()
+        return res

--- a/test/test_ppexpect.py
+++ b/test/test_ppexpect.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import sys
+import os.path
+sys.path.append(os.path.join(os.path.abspath(os.path.dirname(__file__)), '..'))
+
+import unittest
+import ppexpect
+import re
+
+class TestPPExpect(unittest.TestCase):
+    @staticmethod
+    def command(cmd):
+        return ppexpect.Process(['sh', '-c', cmd])
+
+    def test_base(self):
+        p = self.command('sleep 0.9; echo hello')
+        p.expect('hello')
+
+    def test_timeout(self):
+        p = self.command('sleep 0.9; echo hello')
+        with self.assertRaises(ppexpect.TimeoutError):
+            p.expect('hello', timeout=0.5)
+        p.expect('hello')
+
+    def test_regex(self):
+        p = self.command('echo "pid is $$"')
+        rex = re.compile(r'pid is (.*)')
+        m = p.expect(rex)
+        print("pid is %d" % int(m.group(1)))
+
+    def test_close(self):
+        p = self.command('exit 43')
+        res = p.close()
+        self.assertEqual(res, 43)
+        p.close()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If a disk have partial GPT data corrupted (this can result from an initial usage of GPT followed by some MBR tool usage not cleaning properly GPT) Linux kernel will handle correctly the disk using MBR data but `(s)gdisk` (and so our installer) will complain.
This can be an issue even with clean installations if we need to preserve a partition.
Use interactive `gdisk` which has an option to consider only MBR data in this case.

The `pexpect` replacement is there to avoid an additional dependency.