### PR TITLE
__mkinitrd: pass -f to dracut

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -863,7 +863,7 @@ def __mkinitrd(mounts, partition, package, kernel_version, fcoe_interfaces):
     except:
         pass
 
-    cmd = ['dracut', output_file, kernel_version]
+    cmd = ['dracut', '-f', output_file, kernel_version]
 
     if util.runCmd2(['chroot', mounts['root']] + cmd) != 0:
         raise RuntimeError("Failed to create initrd for %s.  This is often due to using an installer that is not the same version of %s as your installation source." % (kernel_version, MY_PRODUCT_BRAND))


### PR DESCRIPTION
Before 5abd998733a76f3609ca1394e4d923eda8f1a8a3 this code was calling grubby's new-kernel-pkg, which unconditionally passes -f to mkinitrd. Not using -f will cause install failure when a driver disk's rpm's scripts have generated an initrd already (as is the case with the intel igb driver)