### PR TITLE
Preserve more stunnel certificates on upgrade

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -462,6 +462,7 @@ class ThirdGenUpgrader(Upgrader):
 
         # Preserve pool certificates across upgrades
         self.restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
+        self.restore_list += [{'dir': 'etc/stunnel/certs'}]
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']
     def completeUpgrade(self, mounts, prev_install, target_disk, backup_partnum, logs_partnum, admin_iface, admin_bridge, admin_config):


### PR DESCRIPTION
When upgrading from 8.3 or later the certificates generated on first boot need to be preserved.  This impacts reinstallation by "upgrading to itself" an existing xcpng-8.3 or xs8.

This completes d74565a5c81b49f2056affb2684d62c22a9d951a and 6d9e2db000685789d9aa2076b2eedde544494122, after which joining a pool with an upgrading master otherwise shows:

 # xe pool-join ...
 The server failed to handle your request, due to an internal error. The given message may give details useful for debugging the problem.
 message: Sys_error("/etc/stunnel/certs/sdn-controller-ca.pem: No such file or directory")