### PR TITLE
Enhance tracing to hunt for restore bug

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -1123,6 +1123,7 @@ def probePartitioningScheme(device):
     if out == 'dos':
         partitionType = constants.PARTITION_DOS
 
+    logger.debug("probePartitioningScheme(%r) => %r", device, partitionType)
     return partitionType
 
 def PartitionTool(device, partitionType=None):

--- a/diskutil.py
+++ b/diskutil.py
@@ -479,10 +479,12 @@ def probeDisk(device):
         swap is a tuple of True or False and the partition device
     """
 
+    logger.debug("probeDisk(%r)", device)
     disk = Disk(device)
     possible_srs = []
 
     tool = PartitionTool(device)
+    tool.dump()
     for num, part in tool.items():
         label = None
         part_device = tool._partitionDevice(num)
@@ -510,6 +512,8 @@ def probeDisk(device):
             disk.swap = (True, part_device)
         elif part['id'] == GPTPartitionTool.ID_EFI_BOOT or part['id'] == GPTPartitionTool.ID_BIOS_BOOT:
             disk.boot = (True, part_device)
+        else:
+            logger.info("part %s has unknown id: %s", num, part)
 
     lv_tool = len(possible_srs) and LVMTool()
     for num in possible_srs:

--- a/restore.py
+++ b/restore.py
@@ -72,6 +72,7 @@ def restoreFromBackup(backup, progress=lambda x: ()):
         try:
             util.mkfs(constants.rootfs_type, restore_partition)
         except Exception as e:
+            logger.critical("Failed to create root filesystem", exc_info=1)
             raise RuntimeError("Failed to create root filesystem: %s" % e)
 
         if efi_boot:


### PR DESCRIPTION
The particular issue turned out to be that the nested UEFI host being restored had several disks attached.  Since this is done as NVMe namespaces of a single disk, all sharing the same ID, udev in dom0 does not have enough info and messes up /dev/disk/by-id/ on which restore relies because of `/etc/xensource-inventory`:

```
 lrwxrwxrwx 1 root root 13 Jul 15 14:28 nvme-QEMU_NVMe_Ctrl_nvme0 -> ../../nvme0n3
 lrwxrwxrwx 1 root root 15 Jul 15 14:28 nvme-QEMU_NVMe_Ctrl_nvme0-part1 -> ../../nvme0n2p1
 lrwxrwxrwx 1 root root 15 Jul 15 14:28 nvme-QEMU_NVMe_Ctrl_nvme0-part2 -> ../../nvme0n1p2
```

Only the addition of the `tool.dump()` call allowed me to connect the "Failed to create root filesystem" error with that longstanding (in)famous issue, but a few other additions were useful to get there.