### PR TITLE
CP-50361 Port 4kn changes from xs8 branch

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -341,7 +341,7 @@ class Answerfile:
                                   sr_type_mapping,
                                   default=default_sr_type)
 
-        if sr_type != SR_TYPE_LARGE_BLOCK and len(large_block_disks) > 0:
+        if SR_TYPE_LARGE_BLOCK and sr_type != SR_TYPE_LARGE_BLOCK and len(large_block_disks) > 0:
             raise AnswerfileException("%s not compatible with SR type %s"
                                       % (", ".join(large_block_disks), sr_type))
 

--- a/backend.py
+++ b/backend.py
@@ -728,19 +728,15 @@ def prepareStorageRepositories(mounts, primary_disk, storage_partnum, guest_disk
 
     partitions = getSRPhysDevs(primary_disk, storage_partnum, guest_disks)
 
-    sr_type_strings = { constants.SR_TYPE_EXT: 'ext',
-                        constants.SR_TYPE_LVM: 'lvm' }
-    sr_type_string = sr_type_strings[sr_type]
-
     # write a config file for the prepare-storage firstboot script:
 
     links = [diskutil.idFromPartition(x) or x for x in partitions]
     fd = open(os.path.join(mounts['root'], constants.FIRSTBOOT_DATA_DIR, 'default-storage.conf'), 'w')
     print("XSPARTITIONS='%s'" % str.join(" ", links), file=fd)
-    print("XSTYPE='%s'" % sr_type_string, file=fd)
+    print("XSTYPE='%s'" % sr_type, file=fd)
     # Legacy names
     print("PARTITIONS='%s'" % str.join(" ", links), file=fd)
-    print("TYPE='%s'" % sr_type_string, file=fd)
+    print("TYPE='%s'" % sr_type, file=fd)
     fd.close()
 
 def make_free_space(mount, required):

--- a/constants.py
+++ b/constants.py
@@ -18,6 +18,7 @@ INSTALL_TYPE_RESTORE = "restore"
 # sr types:
 SR_TYPE_LVM = "lvm"
 SR_TYPE_EXT = "ext"
+# See also SR_TYPE_LARGE_BLOCK at the bottom of this file
 
 # partition schemes:
 PARTITION_DOS = "DOS"
@@ -183,6 +184,14 @@ INIT_SERVICE_FILES = [
 # optional features
 FEATURES_DIR = "/etc/xensource/features"
 HAS_SUPPLEMENTAL_PACKS = os.path.exists(os.path.join(FEATURES_DIR, "supplemental-packs"))
+SR_TYPE_LARGE_BLOCK = None
+try:
+    with open(os.path.join(FEATURES_DIR, "large-block-capable-sr-type")) as f:
+        value = f.read().strip()
+        if value:
+            SR_TYPE_LARGE_BLOCK = value
+except IOError:
+    pass
 
 # Error partitioning disk as in use
 PARTITIONING_ERROR = \

--- a/disktools.py
+++ b/disktools.py
@@ -88,8 +88,10 @@ class LVMTool:
     # Volume group prefixes
     VG_SWAP_PREFIX = 'VG_XenSwap'
     VG_CONFIG_PREFIX = 'VG_XenConfig'
+    # Prefix used by the SR type 'lvm'
     VG_SR_PREFIX = 'VG_XenStorage'
-    VG_EXT_SR_PREFIX = 'XSLocalEXT'
+    # Prefix for non-'lvm' local storage SR types
+    VG_OTHER_SR_PREFIX = 'XSLocal'
 
     PVMOVE = ['pvmove']
     LVCHANGE = ['lvchange']
@@ -348,7 +350,7 @@ class LVMTool:
     def srPartition(self, devicePrefix):
         retVal = self.testPartition(devicePrefix, self.VG_SR_PREFIX)
         if retVal is None:
-            retVal = self.testPartition(devicePrefix, self.VG_EXT_SR_PREFIX)
+            retVal = self.testPartition(devicePrefix, self.VG_OTHER_SR_PREFIX)
         return retVal
 
     def isPartitionConfig(self, device):
@@ -364,7 +366,7 @@ class LVMTool:
     def isPartitionSR(self, device):
         pv = self.deviceToPVOrNone(device)
         return pv is not None and (pv['vg_name'].startswith(self.VG_SR_PREFIX) or \
-                                   pv['vg_name'].startswith(self.VG_EXT_SR_PREFIX))
+                                   pv['vg_name'].startswith(self.VG_OTHER_SR_PREFIX))
 
     def deleteDevice(self, device):
         """Deletes PVs, VGs and LVs associated with a device (partition)"""

--- a/diskutil.py
+++ b/diskutil.py
@@ -284,6 +284,17 @@ def getDiskDeviceSize(dev):
     elif os.path.exists("/sys/block/%s/size" % dev):
         return int(__readOneLineFile__("/sys/block/%s/size" % dev))
 
+def getDiskBlockSize(dev):
+    if not dev.startswith("/dev/"):
+        dev = '/dev/' + dev
+    if isDeviceMapperNode(dev):
+        return getDiskBlockSize(getDeviceSlaves(dev)[0])
+    if dev.startswith("/dev/"):
+        dev = re.match("/dev/(.*)", dev).group(1)
+    dev = dev.replace("/", "!")
+    return int(__readOneLineFile__("/sys/block/%s/queue/logical_block_size"
+                                   % dev))
+
 def getDiskSerialNumber(dev):
     # For Multipath nodes return info about 1st slave
     if not dev.startswith("/dev/"):
@@ -334,18 +345,38 @@ def isRemovable(path):
     else:
         return False
 
+def isLargeBlockDisk(dev):
+    """
+    Determines whether a disk's logical block size is larger than 512 bytes
+    (e.g. 4KB) with the consequence that "lvm" and "ext" SR types will not
+    be able to make use of it.
+    """
+    return getDiskBlockSize(dev) > 512
+
 def blockSizeToGBSize(blocks):
     return (int(blocks) * 512) // (1024 * 1024 * 1024)
 
 def blockSizeToMBSize(blocks):
     return (int(blocks) * 512) // (1024 * 1024)
 
-def getHumanDiskSize(blocks):
-    gb = blockSizeToGBSize(blocks)
+def blockSizeToBytes(blocks):
+    return int(blocks) * 512
+
+def bytesToHuman(num_bytes):
+    kb = num_bytes // 1024
+    mb = kb // 1024
+    gb = mb // 1024
+
     if gb > 0:
         return "%d GB" % gb
-    else:
-        return "%d MB" % blockSizeToMBSize(blocks)
+    if mb > 0:
+        return "%d MB" % mb
+    if kb > 0:
+        return "%d KB" % kb
+    return "%d bytes" % num_bytes
+
+def getHumanDiskSize(blocks):
+    return bytesToHuman(blockSizeToBytes(blocks))
 
 def getExtendedDiskInfo(disk, inMb=0):
     return (getDiskDeviceVendor(disk), getDiskDeviceModel(disk),
@@ -446,6 +477,8 @@ def log_available_disks():
         diskSizes = [getDiskDeviceSize(x) for x in disks]
         diskSizesGB = [blockSizeToGBSize(x) for x in diskSizes]
         logger.log("Disk sizes: %s" % str(diskSizesGB))
+        logger.log("Disk block sizes: %s" % [getDiskBlockSize(x)
+                                             for x in disks])
 
         dom0disks = [x for x in diskSizesGB if constants.min_primary_disk_size <= x]
         if len(dom0disks) == 0:
@@ -463,7 +496,7 @@ class Disk:
 
 INSTALL_RETAIL = 1
 STORAGE_LVM = 1
-STORAGE_EXT3 = 2
+STORAGE_OTHER = 2
 
 def probeDisk(device):
     """Examines device and reports the apparent presence of a XenServer installation and/or related usage
@@ -474,7 +507,7 @@ def probeDisk(device):
         boot is a tuple of True or False and the partition device
         root is a tuple of None or INSTALL_RETAIL and the partition device
         state is a tuple of True or False and the partition device
-        storage is a tuple of None, STORAGE_LVM or STORAGE_EXT3 and the partition device
+        storage is a tuple of None, STORAGE_LVM or STORAGE_OTHER and the partition device
         logs is a tuple of True or False and the partition device
         swap is a tuple of True or False and the partition device
     """
@@ -519,9 +552,8 @@ def probeDisk(device):
             disk.state = (True, part_device)
         elif lv_tool.isPartitionSR(part_device):
             pv = lv_tool.deviceToPVOrNone(part_device)
-            if pv is not None and pv['vg_name'].startswith(lv_tool.VG_EXT_SR_PREFIX):
-                # odd 'ext3 in an LV' SR
-                disk.storage = (STORAGE_EXT3, part_device)
+            if pv is not None and pv['vg_name'].startswith(lv_tool.VG_OTHER_SR_PREFIX):
+                disk.storage = (STORAGE_OTHER, part_device)
             else:
                 disk.storage = (STORAGE_LVM, part_device)
 

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -296,12 +296,21 @@ Format of 'source' and 'driver-source'
 (Re)Install Attributes
 ----------------------
 
-  <installation sr-type="lvm|ext"?>
-  <installation srtype="lvm|ext"?>[D]
+  <installation sr-type="srtype"?>
+  <installation srtype="srtype"?>[D]
+
+    where srtype is one of
+
+      lvm
+      ext
+      the SR type specified in the large-block-capable-sr-type feature file
+        (if present)
 
     Local SR type.
 
-    Default: lvm
+    Default: lvm if the disks included in local SR storage all have 512 byte
+             logical blocks, otherwise (when available) the SR type from
+             the large-block-capable-sr-type feature
 
 
 Upgrade Elements

--- a/doc/features.txt
+++ b/doc/features.txt
@@ -14,3 +14,16 @@ Currently available feature flags are:
 
     This only impacts the UI, the <source> answerfile construct still
     allows to include supplemental packs without this feature flag.
+
+  large-block-capable-sr-type
+
+    Allow the use of an SR type for local storage that (unlike "lvm" and
+    "ext") is not restricted to using disks with 512 byte blocks. The flag
+    file's content must be the name of the SR type.
+
+    The other expectations for such an SR type are:
+    - Its only non-optional creation parameter (as with "lvm" and "ext") is
+      "device", a comma-separated list devices to use.
+    - It should use an identifying prefix for the names of volume groups that
+      it creates, and this prefix should start "XSLocal". (e.g. if the SR type
+      were called "foo", it might use the prefix "XSLocalFOO".)

--- a/tui/installer/__init__.py
+++ b/tui/installer/__init__.py
@@ -122,6 +122,10 @@ def runMainSequence(results, ram_warning, vt_warning, suppress_extra_cd_dialog):
 
         return ret
 
+    def has_guest_disks_fn(answers):
+        guest_disks = answers.get('guest-disks')
+        return guest_disks is not None and len(guest_disks) > 0
+
     if 'install-type' not in results:
         results['install-type'] = constants.INSTALL_TYPE_FRESH
         results['preserve-settings'] = False
@@ -152,6 +156,8 @@ def runMainSequence(results, ram_warning, vt_warning, suppress_extra_cd_dialog):
              predicates=[is_reinstall_fn, requires_repartition]),
         Step(uis.select_guest_disks,
              predicates=[is_clean_install_fn]),
+        Step(uis.get_sr_type,
+             predicates=[is_clean_install_fn, has_guest_disks_fn]),
         Step(uis.confirm_erase_volume_groups,
              predicates=[is_clean_install_fn]),
         Step(tui.repo.select_repo_source,

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -663,7 +663,7 @@ def select_guest_disks(answers):
     for de in diskEntries:
         entries.append((diskutil.getHumanDiskLabel(de), de))
 
-    text = TextboxReflowed(54, "Which disks would you like to use for %s storage?  \n\nOne storage repository will be created that spans the selected disks.  You can choose not to prepare any storage if you wish to create an advanced configuration after installation." % BRAND_GUEST)
+    text = TextboxReflowed(54, "Which disks do you want to use for %s storage?  \n\nOne storage repository will be created that spans the selected disks.  You can choose not to prepare any storage if you want to create an advanced configuration after installation." % BRAND_GUEST)
     buttons = ButtonBar(tui.screen, [('Ok', 'ok'), ('Back', 'back')])
     scroll, _ = snackutil.scrollHeight(3, len(entries))
     cbt = CheckboxTree(3, scroll)
@@ -736,7 +736,7 @@ def get_sr_type(answers):
     else:
         content = TextboxReflowed(54,
                                   "Only disks with a block size of 512 bytes"
-                                  " can be use for %s storage. Please"
+                                  " can be used for %s storage. Please"
                                   " unselect any disks where the block size"
                                   " is different from this."
                                   % BRAND_GUEST)

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -717,7 +717,7 @@ def get_sr_type(answers):
     need_large_block_sr_type = any(diskutil.isLargeBlockDisk(disk)
                                    for disk in guest_disks)
 
-    if not need_large_block_sr_type:
+    if not need_large_block_sr_type or not constants.SR_TYPE_LARGE_BLOCK:
         srtype = answers.get('sr-type', constants.SR_TYPE_LVM)
         txt = "Enable thin provisioning"
         if len(BRAND_VDI) > 0:
@@ -726,22 +726,13 @@ def get_sr_type(answers):
         content = tb
         get_type = lambda: tb.selected() and constants.SR_TYPE_EXT or constants.SR_TYPE_LVM
         buttons = ButtonBar(tui.screen, [('Ok', 'ok'), ('Back', 'back')])
-    elif constants.SR_TYPE_LARGE_BLOCK:
+    else:
         content = TextboxReflowed(40,
                                   "%s storage will be configured for"
                                   " large disk block size."
                                   % BRAND_GUEST)
         get_type = lambda: constants.SR_TYPE_LARGE_BLOCK
         buttons = ButtonBar(tui.screen, [('Ok', 'ok'), ('Back', 'back')])
-    else:
-        content = TextboxReflowed(54,
-                                  "Only disks with a block size of 512 bytes"
-                                  " can be used for %s storage. Please"
-                                  " unselect any disks where the block size"
-                                  " is different from this."
-                                  % BRAND_GUEST)
-        buttons = ButtonBar(tui.screen, [('Back', 'back')])
-        get_type = None
 
     gf = GridFormHelp(tui.screen, 'Virtual Machine Storage Type', 'guestdisk:info2', 1, 4)
     gf.add(content, 0, 0, padding=(0, 0, 0, 1))


### PR DESCRIPTION
This is a cherry pick of the commits in https://github.com/xenserver/host-installer/pull/105. I probably should have done that at the time. Apart from fixing some superficial conflicts, the changes here relative to that PR are the use of the print function rather than print statements, and the use of int rather than long to cast floats.