### PR TITLE
CA-395582: Fix installation with multipath enabled

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -1103,7 +1103,11 @@ class GPTPartitionTool(PartitionToolBase):
         except:
             # Ignore error code which results from inconsistent initial state
             pass
-        self.gdiskCheck([self.SGDISK, '--mbrtogpt', '--clear', self.device])
+        args = [self.SGDISK, '--mbrtogpt', '--clear', self.device]
+        if isDeviceMapperNode(self.device):
+            self.cmdWrap(args)
+        else:
+            self.gdiskCheck(args)
 
         has_esp = False
         for part in table.values():
@@ -1141,7 +1145,10 @@ class GPTPartitionTool(PartitionToolBase):
             if 'partuuid' in part:
                 args += ['--partition-guid=%d:%s' % (num,part['partuuid'])]
         args += [self.device]
-        self.gdiskCheck(args)
+        if isDeviceMapperNode(self.device):
+            self.cmdWrap(args)
+        else:
+            self.gdiskCheck(args)
 
         if isDeviceMapperNode(self.device):
             # Create partitions using device mapper


### PR DESCRIPTION
Commit 6495353cce6a ("CA-392317: Make sure kernel is up to date using Gdisk") added a check to ensure that issues with rereading the partition table are detected. However, rereading the partition table always fails when device-mapper is used (BLKRRPART returns EINVAL) which causes spurious installation failures. The host installer correctly uses kpartx to recreate partitions after repartitioning device-mapper devices so simply ignore the warning from sgdisk when using device-mapper.