### PR TITLE
`restore.py`/`restoreFromBackup()`: Ensure esp mount point is known before setting EFI boot entries

### DIFF
--- a/restore.py
+++ b/restore.py
@@ -84,10 +84,11 @@ def restoreFromBackup(backup, progress=lambda x: ()):
         dest_fs = util.TempMount(restore_partition, 'restore-dest-')
         efi_mounted = False
         try:
+            mounts = {'root': dest_fs.mount_point, 'boot': os.path.join(dest_fs.mount_point, 'boot')}
             if efi_boot:
-                esp = os.path.join(dest_fs.mount_point, 'boot', 'efi')
-                os.makedirs(esp)
-                util.mount(boot_device, esp)
+                mounts['esp'] = os.path.join(dest_fs.mount_point, 'boot', 'efi')
+                os.makedirs(mounts['esp'])
+                util.mount(boot_device, mounts['esp'])
                 efi_mounted = True
 
             # copy files from the backup partition to the restore partition:
@@ -121,8 +122,6 @@ def restoreFromBackup(backup, progress=lambda x: ()):
                     if m:
                         bootlabel = m.group(1)
 
-            mounts = {'root': dest_fs.mount_point, 'boot': os.path.join(dest_fs.mount_point, 'boot')}
-
             # prepare extra mounts for installing bootloader:
             util.bindMount("/dev", "%s/dev" % dest_fs.mount_point)
             util.bindMount("/sys", "%s/sys" % dest_fs.mount_point)
@@ -149,7 +148,7 @@ def restoreFromBackup(backup, progress=lambda x: ()):
             util.umount("%s/sys" % dest_fs.mount_point)
             util.umount("%s/dev" % dest_fs.mount_point)
             if efi_mounted:
-                util.umount(esp)
+                util.umount(mounts['esp'])
             dest_fs.unmount()
     finally:
         backup_fs.unmount()


### PR DESCRIPTION
setEfiBootEntry called here: https://github.com/xenserver/host-installer/blob/master/restore.py#L134
Which requires `mounts['esp']`: https://github.com/xenserver/host-installer/blob/master/backend.py#L1136

Manually tested this fixes the regression

```
INFO     [2024-07-26 13:23:01] Traceback (most recent call last):
  File "/opt/xensource/installer/install.py", line 256, in go
    restore.restoreFromBackup(backup, progress)
  File "/opt/xensource/installer/restore.py", line 143, in restoreFromBackup
    backend.setEfiBootEntry(mounts, disk, boot_partnum, constants.INSTALL_TYPE_RESTORE, branding)
  File "/opt/xensource/installer/backend.py", line 1142, in setEfiBootEntry
    if os.path.exists(os.path.join(mounts['esp'], 'EFI/xenserver/shimx64.efi')):
                                   ~~~~~~^^^^^^^
KeyError: 'esp'
```