### PR TITLE
[XS8] Adding a safeguard for UEFI/legacy config switch

### DIFF
--- a/product.py
+++ b/product.py
@@ -28,6 +28,18 @@ THIS_PLATFORM_VERSION = Version.from_string(version.PLATFORM_VERSION)
 XENSERVER_7_0_0 = Version([2, 1, 0]) # Platform version
 XENSERVER_MIN_VERSION = XENSERVER_7_0_0
 
+def is_rootfs_uefi(mount_point):
+    try:
+        with open(os.path.join(mount_point, 'etc', 'fstab'), 'r') as fstab:
+            for line in fstab:
+                m = re.search(r'^\s*[^#]+\s/boot/efi\s', line)
+                if m:
+                    return True
+    except FileNotFoundError:
+        pass
+
+    return False
+
 class ExistingInstallation:
     def __init__(self, primary_disk, boot_device, state_device):
         self.primary_disk = primary_disk

--- a/product.py
+++ b/product.py
@@ -75,6 +75,15 @@ class ExistingInstallation:
         self.mount_state()
         result = True
         try:
+            # Don't propose to upgrade a BIOS installation with a UEFI installer and conversely
+            existing_is_uefi = is_rootfs_uefi(self.join_state_path())
+            if existing_is_uefi != constants.UEFI_INSTALLER:
+                    logger.log("Cannot upgrade %s, installer mode (%s) does not match existing boot mode (%s)" %
+                                (self.primary_disk,
+                                "uefi" if constants.UEFI_INSTALLER else "legacy",
+                                "uefi" if existing_is_uefi else "legacy"))
+                    return False
+
             # CA-38459: handle missing firstboot directory e.g. Rio
             if os.path.exists(self.join_state_path('etc/firstboot.d/state')):
                 firstboot_files = [ f for f in os.listdir(self.join_state_path('etc/firstboot.d')) \

--- a/product.py
+++ b/product.py
@@ -576,7 +576,12 @@ def findXenSourceBackups():
             if os.path.exists(os.path.join(b.mount_point, '.xen-backup-partition')):
                 backup = XenServerBackup(p, b.mount_point)
                 logger.log("Found a backup: %s" % (repr(backup),))
-                if backup.version >= XENSERVER_MIN_VERSION and \
+                # Don't restore a BIOS backup with a UEFI installer and conversely
+                backup_is_uefi = is_rootfs_uefi(b.mount_point)
+                if backup_is_uefi != constants.UEFI_INSTALLER:
+                    logger.log("Ignoring backup, installer mode (%s) does not match backup boot mode (%s)" %
+                            ("uefi" if constants.UEFI_INSTALLER else "legacy", "uefi" if backup_is_uefi else "legacy" ))
+                elif backup.version >= XENSERVER_MIN_VERSION and \
                         backup.version <= THIS_PLATFORM_VERSION:
                     backups.append(backup)
         except:


### PR DESCRIPTION
Following issue #11, this series adds checks on the current installation and existing backups to not proposed them for upgrade and/or restore if their boot mode (UEFI/legacy) differs from the installer one. To achieve this, a helper function `is_rootf_uefi()` is added.