### PR TITLE
Preserve even more stunnel certs on upgrade

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -192,10 +192,14 @@ class Upgrader(object):
                         pat = f.get('re', None)
                         src_dir = os.path.join(tds.mount_point, f['dir'])
                         if os.path.exists(src_dir):
-                            for ff in os.listdir(src_dir):
-                                fn = os.path.join(f['dir'], ff)
-                                if not pat or pat.match(fn):
-                                    restore_file(tds.mount_point, fn, attr=f.get('attr'))
+                            if pat is not None:
+                                # filter here (though should ideally let restore_file do it)
+                                for ff in os.listdir(src_dir):
+                                    fn = os.path.join(f['dir'], ff)
+                                    if pat.match(fn):
+                                        restore_file(tds.mount_point, fn, attr=f.get('attr'))
+                            else:
+                                restore_file(tds.mount_point, f['dir'])
         finally:
             tds.unmount()
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -189,7 +189,7 @@ class Upgrader(object):
                         assert 'dst' in f
                         restore_file(tds.mount_point, f['src'], f['dst'])
                     elif 'dir' in f:
-                        pat = 're' in f and f['re'] or None
+                        pat = f.get('re', None)
                         src_dir = os.path.join(tds.mount_point, f['dir'])
                         if os.path.exists(src_dir):
                             for ff in os.listdir(src_dir):

--- a/upgrade.py
+++ b/upgrade.py
@@ -478,7 +478,7 @@ class ThirdGenUpgrader(Upgrader):
 
         # Preserve pool certificates across upgrades
         restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
-        restore_list += [{'dir': 'etc/stunnel/certs'}]
+        restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
 
         return restore_list
 


### PR DESCRIPTION
It happens #154 missed a few things:
* an empty `/etc/stunnel/certs` dir would not be restored
* the bundle of `/etc/stunnel/certs` dir would not be restored either