### PR TITLE
IH-416: EXT4 for Dom0 Root & Logs Partitions

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -155,12 +155,6 @@ class Answerfile:
         results['backup-existing-installation'] = True
         results.update(self.parseExistingInstallation())
 
-        # FIXME - obsolete?
-        nodes = getElementsByTagName(self.top_node, ['primary-disk'])
-        if len(nodes) == 1:
-            disk = normalize_disk(getText(nodes[0]))
-            results['primary-disk'] = disk
-
         return results
 
     def parseRestore(self):

--- a/answerfile.py
+++ b/answerfile.py
@@ -227,6 +227,10 @@ class Answerfile:
         logger.log('Primary disk: ' + disk)
         results['primary-disk'] = disk
 
+        results['fs-type'] = getStrAttribute(inst[0], ['fs-type'], default=default_rootfs_type)
+        if results['fs-type'] not in allowed_rootfs_types:
+            raise AnswerfileException("Expected fs-type to be one of %s" % (", ".join(allowed_rootfs_types)))
+
         installations = product.findXenSourceProducts()
         installations = [x for x in installations if x.primary_disk == disk or diskutil.idFromPartition(x.primary_disk) == disk]
         if len(installations) == 0:
@@ -304,6 +308,9 @@ class Answerfile:
         inc_primary = getBoolAttribute(node, ['guest-storage', 'gueststorage'],
                                        default=True)
         results['sr-at-end'] = getBoolAttribute(node, ['sr-at-end'], default=True)
+        results['fs-type'] = getStrAttribute(node, ['fs-type'], default=default_rootfs_type)
+        if results['fs-type'] not in allowed_rootfs_types:
+            raise AnswerfileException("Expected fs-type to be one of %s" % (", ".join(allowed_rootfs_types)))
 
         # Guest disk(s) (Local SR)
         guest_disks = set()

--- a/backend.py
+++ b/backend.py
@@ -143,7 +143,7 @@ def getPrepSequence(ans, interactive):
                         progress_scale=100,
                         pass_progress_callback=True))
     seq += [
-        Task(createDom0DiskFilesystems, A(ans, 'install-type', 'primary-disk', 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'logs-partnum', 'disk-label-suffix'), []),
+        Task(createDom0DiskFilesystems, A(ans, 'install-type', 'primary-disk', 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'logs-partnum', 'disk-label-suffix', 'fs-type'), []),
         Task(mountVolumes, A(ans, 'primary-disk', 'boot-partnum', 'primary-partnum', 'logs-partnum', 'cleanup', 'target-boot-mode'), ['mounts', 'cleanup']),
         ]
     return seq
@@ -177,7 +177,7 @@ def getFinalisationSequence(ans):
         Task(writeKeyboardConfiguration, A(ans, 'mounts', 'keymap'), []),
         Task(configureNetworking, A(ans, 'mounts', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration', 'manual-hostname', 'manual-nameservers', 'network-hardware', 'preserve-settings', 'network-backend'), []),
         Task(prepareSwapfile, A(ans, 'mounts', 'primary-disk', 'swap-partnum', 'disk-label-suffix'), []),
-        Task(writeFstab, A(ans, 'mounts', 'target-boot-mode', 'primary-disk', 'logs-partnum', 'swap-partnum', 'disk-label-suffix'), []),
+        Task(writeFstab, A(ans, 'mounts', 'target-boot-mode', 'primary-disk', 'logs-partnum', 'swap-partnum', 'disk-label-suffix', 'fs-type'), []),
         Task(enableAgent, A(ans, 'mounts', 'network-backend', 'services'), []),
         Task(configureCC, A(ans, 'mounts'), []),
         Task(writeInventory, A(ans, 'installation-uuid', 'control-domain-uuid', 'mounts', 'primary-disk',
@@ -783,7 +783,7 @@ def make_free_space(mount, required):
 ###
 # Create dom0 disk file-systems:
 
-def createDom0DiskFilesystems(install_type, disk, target_boot_mode, boot_partnum, primary_partnum, logs_partnum, disk_label_suffix):
+def createDom0DiskFilesystems(install_type, disk, target_boot_mode, boot_partnum, primary_partnum, logs_partnum, disk_label_suffix, fs_type):
     if target_boot_mode == TARGET_BOOT_MODE_UEFI:
         partition = partitionDevice(disk, boot_partnum)
         try:
@@ -794,7 +794,7 @@ def createDom0DiskFilesystems(install_type, disk, target_boot_mode, boot_partnum
 
     partition = partitionDevice(disk, primary_partnum)
     try:
-        util.mkfs(rootfs_type, partition,
+        util.mkfs(fs_type, partition,
                   ["-L", rootfs_label%disk_label_suffix])
     except Exception as e:
         raise RuntimeError("Failed to create root filesystem: %s" % e)
@@ -803,6 +803,7 @@ def createDom0DiskFilesystems(install_type, disk, target_boot_mode, boot_partnum
     logs_partition = tool.getPartition(logs_partnum)
     if logs_partition:
         run_mkfs = True
+        change_logs_fs_type = diskutil.fs_type_from_device(partitionDevice(disk, logs_partnum)) != fs_type
 
         # If the log partition already exists and is formatted correctly,
         # relabel it. Otherwise create the filesystem.
@@ -814,7 +815,7 @@ def createDom0DiskFilesystems(install_type, disk, target_boot_mode, boot_partnum
             # Ignore the exception as it just means the partition needs to be
             # formatted.
             pass
-        if install_type != INSTALL_TYPE_FRESH and label and label.startswith(logsfs_label_prefix):
+        if install_type != INSTALL_TYPE_FRESH and label and label.startswith(logsfs_label_prefix) and not change_logs_fs_type:
             # If a filesystem which has not been unmounted cleanly is
             # relabelled, it will revert to the original label once it is
             # mounted. To prevent this, fsck the filesystem before relabelling.
@@ -826,7 +827,7 @@ def createDom0DiskFilesystems(install_type, disk, target_boot_mode, boot_partnum
 
         if run_mkfs:
             try:
-                util.mkfs(logsfs_type, partition,
+                util.mkfs(fs_type, partition,
                           ["-L", logsfs_label % disk_label_suffix])
             except Exception as e:
                 raise RuntimeError("Failed to create logs filesystem: %s" % e)
@@ -1297,14 +1298,14 @@ def prepareSwapfile(mounts, primary_disk, swap_partnum, disk_label_suffix):
                       'bs=1024', 'count=%d' % (constants.swap_file_size * 1024)])
         util.runCmd2(['chroot', mounts['root'], 'mkswap', constants.swap_file])
 
-def writeFstab(mounts, target_boot_mode, primary_disk, logs_partnum, swap_partnum, disk_label_suffix):
+def writeFstab(mounts, target_boot_mode, primary_disk, logs_partnum, swap_partnum, disk_label_suffix, fs_type):
 
     tool = PartitionTool(primary_disk)
     swap_partition = tool.getPartition(swap_partnum)
     logs_partition = tool.getPartition(logs_partnum)
 
     fstab = open(os.path.join(mounts['root'], 'etc/fstab'), "w")
-    fstab.write("LABEL=%s    /         %s     defaults   1  1\n" % (rootfs_label%disk_label_suffix, rootfs_type))
+    fstab.write("LABEL=%s    /         %s     defaults   1  1\n" % (rootfs_label%disk_label_suffix, fs_type))
     if target_boot_mode == TARGET_BOOT_MODE_UEFI:
         fstab.write("LABEL=%s    /boot/efi         %s     defaults   0  2\n" % (bootfs_label%disk_label_suffix.upper(), bootfs_type))
 
@@ -1314,7 +1315,7 @@ def writeFstab(mounts, target_boot_mode, primary_disk, logs_partnum, swap_partnu
         if os.path.exists(os.path.join(mounts['root'], constants.swap_file.lstrip('/'))):
             fstab.write("%s          swap      swap   defaults   0  0\n" % (constants.swap_file))
     if logs_partition:
-        fstab.write("LABEL=%s    /var/log         %s     defaults   0  2\n" % (logsfs_label%disk_label_suffix, logsfs_type))
+        fstab.write("LABEL=%s    /var/log         %s     defaults   0  2\n" % (logsfs_label%disk_label_suffix, fs_type))
 
 def enableAgent(mounts, network_backend, services):
     if network_backend == constants.NETWORK_BACKEND_VSWITCH:

--- a/constants.py
+++ b/constants.py
@@ -88,8 +88,8 @@ logs_free_space = 20
 
 # filesystems and partitions types:
 bootfs_type = 'vfat'
-rootfs_type = 'ext3'
-logsfs_type = 'ext3'
+allowed_rootfs_types = ('ext3', 'ext4')
+default_rootfs_type = 'ext4'
 
 # filesystems and partitions labels:
 bootfs_label = "BOOT-%s"

--- a/diskutil.py
+++ b/diskutil.py
@@ -842,3 +842,12 @@ def parentdev_from_devpath(devpath):
 
     # If there is no parent of the parent cannot be determined...
     return None
+
+def fs_type_from_device(device):
+    (rc, stdout) = util.runCmd2(['/bin/lsblk', '-n', '-o', 'FSTYPE', device], with_stdout=True)
+    if rc == 0:
+        return stdout.strip()
+
+    msg = "Failed to identify filesystem type on %s" % device
+    logger.log(msg)
+    raise Exception(msg)

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -322,11 +322,6 @@ Upgrade Elements
     upgraded.
 
 
-  <primary-disk>dev</primary-disk>?[D]
-
-    Specifies the target disk to migrate a flash-based OEM
-    installation to. (5.6 & 5.6 FP1)
-
 Restore Elements
 ----------------
 

--- a/install.py
+++ b/install.py
@@ -98,6 +98,7 @@ def go(ui, args, answerfile_address, answerfile_script):
         'root-password': ('pwdhash', '!!'),
         'services': { s: None for s in constants.SERVICES }, # default state for services, example {'sshd': None}
         'preserve-first-partition': constants.PRESERVE_IF_UTILITY,
+        'fs-type': constants.default_rootfs_type,
         }
     suppress_extra_cd_dialog = False
     serial_console = None

--- a/product.py
+++ b/product.py
@@ -458,7 +458,9 @@ class ExistingRetailInstallation(ExistingInstallation):
         opts = None
         if ro:
             opts = ['ro']
-        self.root_fs = util.TempMount(self.root_device, 'root', opts, 'ext3', boot_device=boot_device)
+
+        fs_type = diskutil.fs_type_from_device(self.root_device)
+        self.root_fs = util.TempMount(self.root_device, 'root', opts, fs_type, boot_device=boot_device)
 
     def unmount_root(self):
         if self.root_fs:
@@ -558,7 +560,7 @@ def findXenSourceBackups():
     for p in partitions:
         b = None
         try:
-            b = util.TempMount(p, 'backup-', ['ro'], 'ext3')
+            b = util.TempMount(p, 'backup-', ['ro'])
             if os.path.exists(os.path.join(b.mount_point, '.xen-backup-partition')):
                 backup = XenServerBackup(p, b.mount_point)
                 logger.log("Found a backup: %s" % (repr(backup),))

--- a/upgrade.py
+++ b/upgrade.py
@@ -338,9 +338,10 @@ class ThirdGenUpgrader(Upgrader):
             tool.commit(log=True)
 
         # format the backup partition:
+        backupfs_type = diskutil.fs_type_from_device(self.source.root_device)
         backup_partition = partitionDevice(target_disk, backup_partnum)
         try:
-            util.mkfs('ext3', backup_partition)
+            util.mkfs(backupfs_type, backup_partition)
         except Exception as e:
             raise RuntimeError("Backup: Failed to format filesystem on %s: %s" % (backup_partition, e))
         progress_callback(10)


### PR DESCRIPTION
Add support for EXT4 root and logs partitions on fresh install and upgrade.
Backup and restore is handled by checking the type of the partition being backed-up/restored-to instead of assuming it's EXT3.
This change is intentionally undocumented in doc/answerfile.txt as we are not expecting to support environments which intentionally divert from the default fs type.

This has been tested manually in all ext3/ext4 combinations (e.g. from ext3->ext3, ext3->ext4, etc.) in fresh installs, upgrades, and restores.
A regression test is being introduced into XenRT, see jobs 4087565 & 4088336 and XenRT PR XXX

This PR depends on commit e72687b44b5968aa275f01a44c112e95a28121fb from https://github.com/xenserver/host-installer/pull/161

For XenServer internal, see PRs:
grub.spec - PR 23
host-upgrade-plugin - PR 42
XenRT - PR 10192