### PR TITLE
Upgrade: forbid upgrading with a key XAPI will reject

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -214,3 +214,6 @@ class MultipathConfig(Enum):
     DISABLED = 0
     ENABLED = 1
     IF_MULTIPLE = 2
+
+# crypto configuration
+RSA_MIN_KEY_SIZE = 2048

--- a/upgrade.py
+++ b/upgrade.py
@@ -4,6 +4,8 @@ import os
 import re
 import shutil
 
+from OpenSSL import crypto
+
 import diskutil
 import product
 from xcp.version import *
@@ -266,11 +268,24 @@ class ThirdGenUpgrader(Upgrader):
             input_data = util.readKeyValueFile(default_storage_conf_path)
             self.storage_type = input_data['TYPE']
 
+        cert_path = os.path.join(primary_fs.mount_point, "etc/xensource/xapi-ssl.pem")
+        with open(cert_path, "r") as cert_file:
+            cert_text = cert_file.read()
+        cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_text)
+        self.key_type = cert.get_pubkey().type()
+        self.key_size = cert.get_pubkey().bits()
+        logger.info("ExistingInstallation %s: certificate key type %s size %s" %
+                    (source, self.key_type, self.key_size))
+
         primary_fs.unmount()
 
     def testUpgradeForbidden(self, tool):
         if tool.partTableType == constants.PARTITION_DOS:
             raise RuntimeError("Upgrade from a DOS partition type is not supported.")
+        if self.key_type != crypto.TYPE_RSA:
+            raise RuntimeError("Current server certificate is not RSA, please regenerate it before upgrade.")
+        if self.key_size < constants.RSA_MIN_KEY_SIZE:
+            raise RuntimeError("Current server certificate is too small (%s bits), please regenerate before upgrade with at least %s bits." % (self.key_size, constants.MIN_KEY_SIZE))
 
     prepTargetStateChanges = []
     prepTargetArgs = ['primary-disk', 'boot-partnum', 'primary-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum']


### PR DESCRIPTION
XAPI now rejects the default keysize of 7.x era, which must be regenerated before upgrading to 8.3.  Let the installer refuse to initiate a situation where a Rolling Pool Upgrade would be unable to proceed, with not-yet-updated slaves holding the running VMs getting refused connection to the updated part of the pool.

This now stops the upgrade with the following screen, but after letting the user give consent for launching the upgrade:

![cert-too-small](https://github.com/user-attachments/assets/12440ba6-f29f-4b60-afcb-e5d1a2f5f80f)
