### PR TITLE
Remove support for very old Xapi DB name

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -138,7 +138,6 @@ INSTALLED_REPOS_DIR = "etc/xensource/installed-repos"
 NETWORK_DB = "var/lib/xcp/networkd.db"
 NETWORKD_DB = "usr/bin/networkd_db"
 NET_SCR_DIR = "etc/sysconfig/network-scripts"
-OLD_XAPI_DB = 'var/xapi/state.db'
 XAPI_DB = 'var/lib/xcp/state.db'
 CLUSTERD_CONF = 'var/opt/xapi-clusterd/db'
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -418,7 +418,6 @@ class ThirdGenUpgrader(Upgrader):
 
         restore_list += [constants.XAPI_DB, 'etc/xensource/license']
         restore_list += [constants.CLUSTERD_CONF]
-        restore_list.append({'src': constants.OLD_XAPI_DB, 'dst': constants.XAPI_DB})
         restore_list.append({'dir': constants.FIRSTBOOT_DATA_DIR, 're': re.compile(r'.*.conf')})
 
         restore_list += ['etc/xensource/syslog.conf']


### PR DESCRIPTION
That name was used in 2012, probably version 5.