### PR TITLE
Backport some changes from master branch to release/xs8

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -106,7 +106,8 @@ def getPrepSequence(ans, interactive):
         Task(util.getUUID, As(ans), ['installation-uuid']),
         Task(util.getUUID, As(ans), ['control-domain-uuid']),
         Task(util.randomLabelStr, As(ans), ['disk-label-suffix']),
-        Task(partitionTargetDisk, A(ans, 'primary-disk', 'installation-to-overwrite', 'preserve-first-partition','sr-on-primary'), ['target-boot-mode', 'boot-partnum', 'primary-partnum', 'backup-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum']),
+        Task(partitionTargetDisk, A(ans, 'primary-disk', 'installation-to-overwrite', 'preserve-first-partition','sr-on-primary'),
+            ['target-boot-mode', 'primary-partnum', 'backup-partnum', 'storage-partnum', 'boot-partnum', 'logs-partnum', 'swap-partnum']),
         ]
 
     if ans['ntp-config-method'] in ("dhcp", "default", "manual"):
@@ -529,7 +530,7 @@ def configureNTP(mounts, ntp_config_method, ntp_servers):
 # This is attempting to understand the desired layout of the future partitioning
 # based on options passed and status of disk (like partition to retain).
 # This should be used for upgrade or install, not for restore.
-# Returns 'target-boot-mode', 'boot-partnum', 'primary-partnum', 'backup-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum'
+# Returns 'target-boot-mode', 'primary-partnum', 'backup-partnum', 'storage-partnum', 'boot-partnum', 'logs-partnum', 'swap-partnum'
 def partitionTargetDisk(disk, existing, preserve_first_partition, create_sr_part):
     logger.log("Installer booted in %s mode" % ("UEFI" if constants.UEFI_INSTALLER else "legacy"))
 
@@ -557,12 +558,12 @@ def partitionTargetDisk(disk, existing, preserve_first_partition, create_sr_part
 
         logger.log("Upgrading, target_boot_mode: %s" % target_boot_mode)
 
-        # Return install mode and numbers of boot, primary, backup, log, swap and SR partitions
+        # Return install mode and numbers of primary, backup, SR, boot, log and swap partitions
         storage_partition = tool.getPartition(primary_part+2)
         if storage_partition:
-            return (target_boot_mode, boot_partnum, primary_part, primary_part+1, primary_part+4, primary_part+5, primary_part+2)
+            return (target_boot_mode, primary_part, primary_part+1, primary_part+2, boot_partnum, primary_part+4, primary_part+5)
         else:
-            return (target_boot_mode, boot_partnum, primary_part, primary_part+1, primary_part+4, primary_part+5, 0)
+            return (target_boot_mode, primary_part, primary_part+1, 0, boot_partnum, primary_part+4, primary_part+5)
 
     tool = PartitionTool(disk)
 
@@ -591,7 +592,7 @@ def partitionTargetDisk(disk, existing, preserve_first_partition, create_sr_part
 
     logger.log("Fresh install, target_boot_mode: %s" % target_boot_mode)
 
-    return (target_boot_mode, boot_part, primary_part, primary_part + 1, primary_part + 4, primary_part + 5, sr_part)
+    return (target_boot_mode, primary_part, primary_part + 1, sr_part, boot_part, primary_part + 4, primary_part + 5)
 
 def removeBlockingVGs(disks):
     for vg in diskutil.findProblematicVGs(disks):

--- a/backend.py
+++ b/backend.py
@@ -188,7 +188,8 @@ def getFinalisationSequence(ans):
         Task(enableAgent, A(ans, 'mounts', 'network-backend', 'services'), []),
         Task(configureCC, A(ans, 'mounts'), []),
         Task(writeInventory, A(ans, 'installation-uuid', 'control-domain-uuid', 'mounts', 'primary-disk',
-                               'backup-partnum', 'storage-partnum', 'guest-disks', 'net-admin-bridge',
+                               'backup-partnum', 'logs-partnum', 'boot-partnum', 'swap-partnum', 'storage-partnum',
+                               'guest-disks', 'net-admin-bridge',
                                'branding', 'net-admin-configuration', 'host-config', 'install-type'), []),
         Task(writeXencommons, A(ans, 'control-domain-uuid', 'mounts'), []),
         Task(configureISCSI, A(ans, 'mounts', 'primary-disk'), []),
@@ -1562,7 +1563,8 @@ def writeXencommons(controlID, mounts):
     with open(os.path.join(mounts['root'], constants.XENCOMMONS_FILE), "w") as f:
         f.write(contents)
 
-def writeInventory(installID, controlID, mounts, primary_disk, backup_partnum, storage_partnum, guest_disks, admin_bridge, branding, admin_config, host_config, install_type):
+def writeInventory(installID, controlID, mounts, primary_disk, backup_partnum, logs_partnum, boot_partnum, swap_partnum,
+                   storage_partnum, guest_disks, admin_bridge, branding, admin_config, host_config, install_type):
     inv = open(os.path.join(mounts['root'], constants.INVENTORY_FILE), "w")
     if 'product-brand' in branding:
        inv.write("PRODUCT_BRAND='%s'\n" % branding['product-brand'])
@@ -1587,7 +1589,15 @@ def writeInventory(installID, controlID, mounts, primary_disk, backup_partnum, s
     inv.write("PLATFORM_NAME='%s'\n" % branding['platform-name'])
     inv.write("PLATFORM_VERSION='%s'\n" % branding['platform-version'])
 
-    layout = 'ROOT,BACKUP,LOG,BOOT,SWAP'
+    layout = 'ROOT'
+    if backup_partnum > 0:
+        layout += ',BACKUP'
+    if logs_partnum > 0:
+        layout += ',LOG'
+    if boot_partnum > 0:
+        layout += ',BOOT'
+    if swap_partnum > 0:
+        layout += ',SWAP'
     if storage_partnum > 0:
         layout += ',SR'
     inv.write("PARTITION_LAYOUT='%s'\n" % layout)

--- a/constants.py
+++ b/constants.py
@@ -139,7 +139,6 @@ INSTALLED_REPOS_DIR = "etc/xensource/installed-repos"
 NETWORK_DB = "var/lib/xcp/networkd.db"
 NETWORKD_DB = "usr/bin/networkd_db"
 NET_SCR_DIR = "etc/sysconfig/network-scripts"
-OLD_XAPI_DB = 'var/xapi/state.db'
 XAPI_DB = 'var/lib/xcp/state.db'
 CLUSTERD_CONF = 'var/opt/xapi-clusterd/db'
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -41,7 +41,6 @@ class Upgrader(object):
     def __init__(self, source):
         """ source is the ExistingInstallation object we're to upgrade. """
         self.source = source
-        self.restore_list = []
 
     def upgrades(cls, product, version, variant):
         return (cls.upgrades_product == product and
@@ -76,9 +75,9 @@ class Upgrader(object):
         return
 
     def buildRestoreList(self, src_base):
-        """ Add filenames to self.restore_list which will be copied by
+        """ Returns list of filenames which will be copied by
         completeUpgrade(). """
-        return
+        return []
 
     completeUpgradeArgs = ['mounts', 'primary-disk', 'backup-partnum']
     def completeUpgrade(self, mounts, target_disk, backup_partnum):
@@ -170,11 +169,11 @@ class Upgrader(object):
         backup_volume = partitionDevice(target_disk, backup_partnum)
         tds = util.TempMount(backup_volume, 'upgrade-src-', options=['ro'])
         try:
-            self.buildRestoreList(tds.mount_point)
+            restore_list = self.buildRestoreList(tds.mount_point)
             init_id_maps(tds.mount_point, mounts['root'])
 
             logger.log("Restoring preserved files")
-            for f in self.restore_list:
+            for f in restore_list:
                 if isinstance(f, str):
                     restore_file(tds.mount_point, f)
                 elif isinstance(f, dict):
@@ -522,66 +521,67 @@ class ThirdGenUpgrader(Upgrader):
         return installID, controlID
 
     def buildRestoreList(self, src_base):
-        self.restore_list += ['etc/xensource/ptoken', 'etc/xensource/pool.conf',
-                              'etc/xensource/xapi-ssl.pem', 'etc/xensource/xapi-pool-tls.pem']
-        self.restore_list.append({'dir': 'etc/ssh', 're': re.compile(r'.*/ssh_host_.+')})
+        restore_list = []
+        restore_list += ['etc/xensource/ptoken', 'etc/xensource/pool.conf',
+                         'etc/xensource/xapi-ssl.pem', 'etc/xensource/xapi-pool-tls.pem']
+        restore_list.append({'dir': 'etc/ssh', 're': re.compile(r'.*/ssh_host_.+')})
 
-        self.restore_list += [ 'etc/sysconfig/network']
-        self.restore_list.append({'dir': 'etc/sysconfig/network-scripts', 're': re.compile(r'.*/ifcfg-[a-z0-9.]+')})
+        restore_list += [ 'etc/sysconfig/network']
+        restore_list.append({'dir': 'etc/sysconfig/network-scripts', 're': re.compile(r'.*/ifcfg-[a-z0-9.]+')})
 
-        self.restore_list += [constants.XAPI_DB, 'etc/xensource/license']
-        self.restore_list += [constants.CLUSTERD_CONF]
-        self.restore_list.append({'src': constants.OLD_XAPI_DB, 'dst': constants.XAPI_DB})
-        self.restore_list.append({'dir': constants.FIRSTBOOT_DATA_DIR, 're': re.compile(r'.*.conf')})
+        restore_list += [constants.XAPI_DB, 'etc/xensource/license']
+        restore_list += [constants.CLUSTERD_CONF]
+        restore_list.append({'src': constants.OLD_XAPI_DB, 'dst': constants.XAPI_DB})
+        restore_list.append({'dir': constants.FIRSTBOOT_DATA_DIR, 're': re.compile(r'.*.conf')})
 
-        self.restore_list += ['etc/xensource/syslog.conf']
+        restore_list += ['etc/xensource/syslog.conf']
 
-        self.restore_list.append({'src': 'etc/xensource-inventory', 'dst': 'var/tmp/.previousInventory'})
+        restore_list.append({'src': 'etc/xensource-inventory', 'dst': 'var/tmp/.previousInventory'})
 
         # CP-1508: preserve AD config
-        self.restore_list += ['etc/resolv.conf', 'etc/krb5.conf', 'etc/krb5.keytab']
-        self.restore_list.append({'dir': 'var/lib/samba'})
+        restore_list += ['etc/resolv.conf', 'etc/krb5.conf', 'etc/krb5.keytab']
+        restore_list.append({'dir': 'var/lib/samba'})
 
         # CP-35398: Integrate automatic upgrade tool from PBIS to winbind
-        self.restore_list += ['var/lib/pbis/db/registry.db']
+        restore_list += ['var/lib/pbis/db/registry.db']
 
         # CA-47142: preserve v6 cache
-        self.restore_list += [{'src': 'var/xapi/lpe-cache', 'dst': 'var/lib/xcp/lpe-cache'}]
+        restore_list += [{'src': 'var/xapi/lpe-cache', 'dst': 'var/lib/xcp/lpe-cache'}]
 
         # CP-2056: preserve RRDs etc
-        self.restore_list += [{'src': 'var/xapi/blobs', 'dst': 'var/lib/xcp/blobs'}]
-        self.restore_list += [{'src': 'var/lib/xcp/blobs', 'dst': 'var/lib/xcp/blobs'}]
+        restore_list += [{'src': 'var/xapi/blobs', 'dst': 'var/lib/xcp/blobs'}]
+        restore_list += [{'src': 'var/lib/xcp/blobs', 'dst': 'var/lib/xcp/blobs'}]
 
-        self.restore_list.append('etc/sysconfig/mkinitrd.latches')
+        restore_list.append('etc/sysconfig/mkinitrd.latches')
 
         # EA-1069: Udev network device naming
-        self.restore_list += [{'dir': 'etc/sysconfig/network-scripts/interface-rename-data'}]
-        self.restore_list += [{'dir': 'etc/sysconfig/network-scripts/interface-rename-data/.from_install'}]
+        restore_list += [{'dir': 'etc/sysconfig/network-scripts/interface-rename-data'}]
+        restore_list += [{'dir': 'etc/sysconfig/network-scripts/interface-rename-data/.from_install'}]
 
         # CA-67890: preserve root's ssh state
-        self.restore_list += [{'dir': 'root/.ssh'}]
+        restore_list += [{'dir': 'root/.ssh'}]
 
         # CA-82709: preserve networkd.db for Tampa upgrades
-        self.restore_list.append(constants.NETWORK_DB)
+        restore_list.append(constants.NETWORK_DB)
 
         # CP-9653: preserve Oracle 5 blacklist
-        self.restore_list += ['etc/pygrub/rules.d/oracle-5.6']
+        restore_list += ['etc/pygrub/rules.d/oracle-5.6']
 
         # CA-150889: backup multipath config
-        self.restore_list.append({'src': 'etc/multipath.conf', 'dst': 'etc/multipath.conf.bak'})
+        restore_list.append({'src': 'etc/multipath.conf', 'dst': 'etc/multipath.conf.bak'})
 
-        self.restore_list += ['etc/locale.conf', 'etc/machine-id', 'etc/vconsole.conf']
+        restore_list += ['etc/locale.conf', 'etc/machine-id', 'etc/vconsole.conf']
 
         # CP-12750: Increase log size when dedicated partion is on the disk
-        self.restore_list += ['etc/sysconfig/logrotate']
+        restore_list += ['etc/sysconfig/logrotate']
 
         # CA-195388: Preserve /etc/mdadm.conf across upgrades
-        self.restore_list += ['etc/mdadm.conf']
+        restore_list += ['etc/mdadm.conf']
 
-        self.restore_list += ['var/lib/xcp/verify_certificates']
+        restore_list += ['var/lib/xcp/verify_certificates']
 
         # CP-42523: NRPE service config
-        self.restore_list += ['etc/nagios/nrpe.cfg', {'dir': 'etc/nrpe.d'}]
+        restore_list += ['etc/nagios/nrpe.cfg', {'dir': 'etc/nrpe.d'}]
 
         # CP-44441: SNMP service config
         # From XS 8.4 SNMP feature is supported, and new file /etc/snmp/snmp.xs.conf is added
@@ -590,12 +590,14 @@ class ThirdGenUpgrader(Upgrader):
         # xapi snmp plugin.
         snmp_xs_conf = 'etc/snmp/snmp.xs.conf'
         if os.path.isfile(os.path.join(src_base, snmp_xs_conf)):
-            self.restore_list += [snmp_xs_conf, 'etc/snmp/snmpd.xs.conf',
-                                  'etc/sysconfig/snmpd', 'var/lib/net-snmp/snmpd.conf']
+            restore_list += [snmp_xs_conf, 'etc/snmp/snmpd.xs.conf',
+                             'etc/sysconfig/snmpd', 'var/lib/net-snmp/snmpd.conf']
 
         # Preserve pool certificates across upgrades
-        self.restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
-        self.restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
+        restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
+        restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
+
+        return restore_list
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']
     def completeUpgrade(self, mounts, prev_install, target_disk, backup_partnum, logs_partnum, admin_iface, admin_bridge, admin_config):

--- a/upgrade.py
+++ b/upgrade.py
@@ -531,7 +531,6 @@ class ThirdGenUpgrader(Upgrader):
 
         restore_list += [constants.XAPI_DB, 'etc/xensource/license']
         restore_list += [constants.CLUSTERD_CONF]
-        restore_list.append({'src': constants.OLD_XAPI_DB, 'dst': constants.XAPI_DB})
         restore_list.append({'dir': constants.FIRSTBOOT_DATA_DIR, 're': re.compile(r'.*.conf')})
 
         restore_list += ['etc/xensource/syslog.conf']


### PR DESCRIPTION
Backport these commits

1. Remove support for very old Xapi DB name
2. Use partition numbers to sort `partitionTargetDisk` output
3. Dynamically compute layout string based on partition availability
4. Change `buildRestoreList` to return list of files
