### PR TITLE
CA-403412: Do not backup GPT layout on temporary directory

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -477,11 +477,6 @@ class ThirdGenUpgrader(Upgrader):
             if util.runCmd2("tar -C '%s' -c -T - | tar -C '%s' -x" % (primary_fs.mount_point, backup_dir), inputtext='\n'.join(files_list)) != 0:
                 raise RuntimeError("Backup failed")
             progress_callback(100)
-
-            # save the GPT table
-            rc, err = util.runCmd2(["sgdisk", "-b", os.path.join(backup_dir, '.xen-gpt.bin'), target_disk], with_stderr=True)
-            if rc != 0:
-                raise RuntimeError("Failed to save partition layout: %s" % err)
         finally:
             primary_fs.unmount()
 


### PR DESCRIPTION
If the backup is done into the temporary directory we don't be able to use it on failure so don't do it.
This also fixes a problem of failure doing such backup; this occurred in an installation with backup GPT correct but invalid primary GPT.