### PR TITLE
CA-405278: Set ucode=scan on Xen command line

### DIFF
--- a/bootloader/grub-usb.patch
+++ b/bootloader/grub-usb.patch
@@ -7,4 +7,4 @@
 +search --file --set /install.img
  
  menuentry "install" {
-     multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+     multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga ucode=scan

--- a/bootloader/grub.cfg
+++ b/bootloader/grub.cfg
@@ -17,13 +17,13 @@ insmod ext2
 set timeout=5
 
 menuentry "install" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga ucode=scan
     module2 /boot/vmlinuz console=hvc0 console=tty0
     module2 /install.img
 }
 
 menuentry "no-serial" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M console=vga
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M console=vga ucode=scan
     module2 /boot/vmlinuz console=tty0
     module2 /install.img
 }
@@ -35,20 +35,20 @@ menuentry "safe" {
 }
 
 menuentry "multipath" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga ucode=scan
     module2 /boot/vmlinuz console=hvc0 console=tty0 device_mapper_multipath=enabled
     module2 /install.img
 }
 
 menuentry "shell" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga ucode=scan
     module2 /boot/vmlinuz console=hvc0 console=tty0 bash-shell
     module2 /install.img
 }
 
 submenu "advanced-options" {
     menuentry "common-criteria-prep" {
-        multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+        multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga ucode=scan
         module2 /boot/vmlinuz console=hvc0 console=tty0 cc-preparations
         module2 /install.img
     }


### PR DESCRIPTION
We want to load microcode (if present) during installer boot, as some mitigations are needed (e.g. GDS to aviod having to disable AVX, which is now required by XenServer 9).

As such, set `ucode=scan` on all boot options execpt the `safe` one.