### PR TITLE
CP-53300: Add 'Memtest86+ (UEFI)' boot menu

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1044,6 +1044,12 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
                                  root=constants.rootfs_label%disk_label_suffix)
         boot_config.append("safe", e)
 
+    e = bootloader.MenuEntry(hypervisor="", hypervisor_args="", kernel="/boot/memtest86+x64.efi",
+                            kernel_args=' '.join([common_kernel_params, "console=tty0", kernel_console_params]),
+                            initrd="", title="Memtest86+ (UEFI)",
+                            root=constants.rootfs_label%disk_label_suffix)
+    boot_config.append("memtest", e)
+
     e = bootloader.MenuEntry(hypervisor="/boot/xen-fallback.gz",
                              hypervisor_args=' '.join([common_xen_params, common_xen_unsafe_params, xen_mem_params]),
                              kernel="/boot/vmlinuz-fallback",


### PR DESCRIPTION
memtest86+ is updated to install the kernel into /boot This commit add a conresponding grub menu to load the kernel