### PR TITLE
[XS8] Backport DHCP hostname fix

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1408,7 +1408,7 @@ def writeResolvConf(mounts, hn_conf, ns_conf):
         except:
             pass
     else:
-        hostname = 'localhost.localdomain'
+        hostname = ''
 
     # /etc/hostname:
     eh = open('%s/etc/hostname' % mounts['root'], 'w')


### PR DESCRIPTION
Users get hit by DHCP hostname setting not working on versions 10.x too.

See e.g. https://xcp-ng.org/forum/topic/10414/static-hostname-overriding-dhcp-assigned-hostname
