### PR TITLE
CA-400058: fix preserve-first-partition installation

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -588,6 +588,9 @@ def partitionTargetDisk(disk, existing, preserve_first_partition, create_sr_part
     # Preserve any utility partitions unless user told us to zap 'em
     primary_part = 1
     if preserve_first_partition == 'true':
+        utilparts = tool.utilityPartitions()
+        if len(utilparts) == 0:
+            raise RuntimeError("Installer only supports a single Utility Partition at partition 1, but there is no Utility Partitions")
         primary_part += 1
     elif preserve_first_partition == constants.PRESERVE_IF_UTILITY:
         utilparts = tool.utilityPartitions()


### PR DESCRIPTION
if preserve-first-partition is yes in answer file, then installer fails with an IndexError because it tries to access a partition which does not exist

simulate the installation failure, and we get error message as follows,

"Installation failed on !genus-34-67d: RuntimeError: Installer only supports a single Utility Partition at partition 1, but there is no Utility Partitions"