### PR TITLE
CA-404794: Require an IPv4 address for the network to be up

### DIFF
--- a/netutil.py
+++ b/netutil.py
@@ -88,7 +88,7 @@ def reloadNetwork(timeout=20):
     """ Use networkctl to reload the configuration """
     util.runCmd2(["networkctl", "reload"])
     # Command return immediately, wait until network is up
-    ret = util.runCmd2(["/usr/lib/systemd/systemd-networkd-wait-online", f"--timeout={timeout}"])
+    ret = util.runCmd2(["/usr/lib/systemd/systemd-networkd-wait-online", "--ipv4", f"--timeout={timeout}"])
     if ret:
         LOG.error(f"Timeout {timeout} waiting for network online")
     return ret


### PR DESCRIPTION
The call to systemd-networkd-wait-online waits for all managed links' operational state to be higher than "degraded" (i.e. "enslaved" or "routable"). Effectively, this means that the link has a routable address.

In some situations, the link gets an IPv6 link-local address at which point it is considered "online". This causes a race condition and intermittent failures when doing automated installs that require an IPv4 address but the interface does not yet have an IPv4 address yet (e.g. because of a slow DHCP server).

Fix this by requring an IPv4 address for the link to be considered up. This will need to be reworked in the future when XenServer fully supports IPv6 in the installer.