### PR TITLE
CA-407115: Remove invalid arguments from memtest86+

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1045,7 +1045,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
         boot_config.append("safe", e)
 
     e = bootloader.MenuEntry(hypervisor="", hypervisor_args="", kernel="/boot/memtest86+x64.efi",
-                            kernel_args=' '.join(["console=tty0", kernel_console_params]),
+                            kernel_args="",
                             initrd="", title="Memtest86+ (UEFI)",
                             root=constants.rootfs_label%disk_label_suffix)
     boot_config.append("memtest", e)


### PR DESCRIPTION
xcp/bootloader.py/readGrub2 parses the kernel args for each entries in grub.cfg: 
```
elif l.startswith("linux"):
    kernel, kernel_args = (l.split(None, 1)
                           [1].split(None, 1))
```
Missing args will result in an error.

Added args to make it the same as in XS9 host:/boot/efi/EFi/xenserver/grub.cfg

+++++++++++++++++++++++++++
Updated:
Removed invalid arguments from memtest86+, and raised another PR to handle the case of an entry with no additional arguments