### PR TITLE
CP-53844: Fix writing file downloaded from a URL

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -310,7 +310,7 @@ class MainYumRepository(YumRepositoryWithInfo):
             try:
                 infh = self._accessor.openAddress(keyfile)
                 key_path = os.path.join('/root', os.path.basename(keyfile))
-                outfh = open(key_path, "w")
+                outfh = open(key_path, "wb")
                 outfh.write(infh.read())
                 return """
 gpgcheck=1


### PR DESCRIPTION
With Python 3 file data came in binary form.
Open the file we want to write as binary to avoid having to convert binary to character and write data as read from URL.