### PR TITLE
CA-408238: Support basic authentication to HTTP server with different port

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -636,10 +636,10 @@ class URLAccessor(Accessor):
             username = self._url.getUsername()
             if username is not None:
                 logger.log("Using basic HTTP authentication")
-                hostname = self._url.getHostname()
+                baseUrl = self._url.getBaseURL()
                 password = self._url.getPassword()
                 self.passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-                self.passman.add_password(None, hostname, username, password)
+                self.passman.add_password(None, baseUrl, username, password)
                 self.authhandler = urllib.request.HTTPBasicAuthHandler(self.passman)
                 self.opener = urllib.request.build_opener(self.authhandler)
                 urllib.request.install_opener(self.opener)

--- a/util.py
+++ b/util.py
@@ -261,7 +261,7 @@ def fetchFile(source, dest):
             url = URL(source)
             if url.getScheme() in ['http', 'https'] and url.getUsername(): # Auth HTTP(s)
                 passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
-                passman.add_password(None, url.getHostname(), url.getUsername(), url.getPassword())
+                passman.add_password(None, url.getBaseURL(), url.getUsername(), url.getPassword())
                 handler = urllib2.HTTPBasicAuthHandler(passman)
                 urllib2.install_opener(urllib2.build_opener(handler))
                 request = url.getPlainURL()
@@ -438,3 +438,10 @@ class URL(object):
             assert self.password is None
 
             return self.url
+
+    def getBaseURL(self):
+        """Get the URL with schema and network location without username/password."""
+
+        url = self.getPlainURL()
+        parts = urllib.parse.urlsplit(url)
+        return urllib.parse.urlunsplit(urllib.parse.SplitResult(parts.scheme, parts.netloc, '', '', ''))


### PR DESCRIPTION
The second parameter for `add_password` is a partial URL, not a hostname. Setting just the hostname make the authentication apply only if using default port.
Compute a URL with schema and port information.