### PR TITLE
Remove warning in regular expression

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -795,7 +795,7 @@ def installFromYum(targets, mounts, progress_callback, cachedir):
         count = 0
         total = 0
         verify_count = 0
-        progressLine = re.compile('.*?(\d+)/(\d+)$')
+        progressLine = re.compile(r'.*?(\d+)/(\d+)$')
         progressLineV5 = re.compile(r'^\[ *(\d+)/(\d+)\] (Installing|Upgrading) ')
 
         def updateInstallProgress(m):


### PR DESCRIPTION
Specifically:
   SyntaxWarning: invalid escape sequence '\d'