### PR TITLE
Allows invalid UTF-8 output from dnf execution

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -797,7 +797,10 @@ def installFromYum(targets, mounts, progress_callback, cachedir):
         verify_count = 0
         progressLine = re.compile('.*?(\d+)/(\d+)$')
         while True:
-            line = p.stdout.readline()
+            try:
+                line = p.stdout.readline()
+            except:
+                continue
             if not line:
                 break
             line = line.rstrip()


### PR DESCRIPTION
Dnf output could be intermixed with script output which potentially cause the installation to fail if the output contains invalid UTF-8 encoded characters.
Ignore these lines.