### PR TITLE
Correct name for renamed "fs_type" variable

### DIFF
--- a/restore.py
+++ b/restore.py
@@ -81,7 +81,7 @@ def restoreFromBackup(backup, progress=lambda x: ()):
             try:
                 util.mkfs(restore_fs_type, logs_partition)
             except OSError as e:
-                raise RuntimeError("Failed to format logs filesystem (%s): %s" % (fs_type, e))
+                raise RuntimeError("Failed to format logs filesystem (%s): %s" % (restore_fs_type, e))
 
         try:
             util.mkfs('vfat', boot_device)


### PR DESCRIPTION
The variable was renamed in commit 25f4ee21759e3e
(cfr "IH-416, CP-31054, CP-31055: Optional EXT4 Support"). 
This was discovered thanks for instrumentation of Bernhard.