### PR TITLE
Unraveling "upgrade" and "reinstall"

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -150,7 +150,7 @@ class Answerfile:
     def parseUpgrade(self):
         results = {}
 
-        results['install-type'] = INSTALL_TYPE_REINSTALL
+        results['install-type'] = INSTALL_TYPE_UPGRADE
         results['preserve-settings'] = True
         results['backup-existing-installation'] = True
         results.update(self.parseExistingInstallation())

--- a/backend.py
+++ b/backend.py
@@ -122,7 +122,7 @@ def getPrepSequence(ans, interactive):
             Task(writeDom0DiskPartitions, A(ans, 'primary-disk', 'boot-partnum', 'primary-partnum', 'backup-partnum', 'logs-partnum', 'swap-partnum', 'storage-partnum', 'sr-at-end'),[]),
             ]
         seq.append(Task(writeGuestDiskPartitions, A(ans,'primary-disk', 'guest-disks'), []))
-    elif ans['install-type'] == INSTALL_TYPE_REINSTALL:
+    elif ans['install-type'] == INSTALL_TYPE_UPGRADE:
         seq.append(Task(getUpgrader, A(ans, 'installation-to-overwrite'), ['upgrader']))
         if 'backup-existing-installation' in ans and ans['backup-existing-installation']:
             seq.append(Task(doBackup,
@@ -211,7 +211,7 @@ def getFinalisationSequence(ans):
     if ans['ntp-config-method'] != "none":
         seq.append(Task(configureNTP, A(ans, 'mounts', 'ntp-config-method', 'ntp-servers'), []))
     # complete upgrade if appropriate:
-    if ans['install-type'] == constants.INSTALL_TYPE_REINSTALL:
+    if ans['install-type'] == constants.INSTALL_TYPE_UPGRADE:
         seq.append( Task(completeUpgrade, lambda a: [ a['upgrader'] ] + [ a[x] for x in a['upgrader'].completeUpgradeArgs ], []) )
 
     # run the users's scripts
@@ -1099,7 +1099,7 @@ def installBootLoader(mounts, disk, boot_partnum, primary_partnum, branding,
 def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
     def check_efibootmgr_err(rc, err, install_type, err_type):
         if rc != 0:
-            if install_type in (INSTALL_TYPE_REINSTALL, INSTALL_TYPE_RESTORE):
+            if install_type in (INSTALL_TYPE_UPGRADE, INSTALL_TYPE_RESTORE):
                 logger.error("%s: %s" % (err_type, err))
             else:
                 raise RuntimeError("%s: %s" % (err_type, err))

--- a/constants.py
+++ b/constants.py
@@ -12,7 +12,7 @@ EXIT_USER_CANCEL = 2
 
 # install types:
 INSTALL_TYPE_FRESH = "fresh"
-INSTALL_TYPE_REINSTALL = "reinstall"
+INSTALL_TYPE_UPGRADE = "upgrade"
 INSTALL_TYPE_RESTORE = "restore"
 
 # sr types:

--- a/tui/installer/__init__.py
+++ b/tui/installer/__init__.py
@@ -51,7 +51,7 @@ def runMainSequence(results, ram_warning, vt_warning, suppress_extra_cd_dialog):
 
     has_multiple_nics = lambda a: len(a['network-hardware'].keys()) > 1
 
-    is_reinstall_fn = lambda a: a['install-type'] == constants.INSTALL_TYPE_UPGRADE
+    is_upgrade_fn = lambda a: a['install-type'] == constants.INSTALL_TYPE_UPGRADE
     is_clean_install_fn = lambda a: a['install-type'] == constants.INSTALL_TYPE_FRESH
     is_not_restore_fn = lambda a: a['install-type'] != constants.INSTALL_TYPE_RESTORE
 
@@ -143,17 +143,17 @@ def runMainSequence(results, ram_warning, vt_warning, suppress_extra_cd_dialog):
         Step(uis.upgrade_settings_warning,
              predicates=[upgrade_but_no_settings_predicate]),
         Step(uis.ha_master_upgrade,
-             predicates=[is_reinstall_fn, ha_enabled]),
+             predicates=[is_upgrade_fn, ha_enabled]),
         Step(uis.remind_driver_repos,
-             predicates=[is_reinstall_fn, preserve_settings]),
+             predicates=[is_upgrade_fn, preserve_settings]),
         Step(uis.backup_existing_installation,
-             predicates=[is_reinstall_fn, optional_backup]),
+             predicates=[is_upgrade_fn, optional_backup]),
         Step(uis.force_backup_screen,
-             predicates=[is_reinstall_fn, requires_backup]),
+             predicates=[is_upgrade_fn, requires_backup]),
         Step(uis.select_primary_disk,
              predicates=[is_clean_install_fn]),
         Step(uis.repartition_existing,
-             predicates=[is_reinstall_fn, requires_repartition]),
+             predicates=[is_upgrade_fn, requires_repartition]),
         Step(uis.select_guest_disks,
              predicates=[is_clean_install_fn]),
         Step(uis.get_sr_type,

--- a/tui/installer/__init__.py
+++ b/tui/installer/__init__.py
@@ -45,13 +45,13 @@ def runMainSequence(results, ram_warning, vt_warning, suppress_extra_cd_dialog):
                len(answers['backups']) == 0
 
     def upgrade_but_no_settings_predicate(answers):
-        return answers['install-type'] == constants.INSTALL_TYPE_REINSTALL and \
+        return answers['install-type'] == constants.INSTALL_TYPE_UPGRADE and \
             ('installation-to-overwrite' not in answers or \
                  not answers['installation-to-overwrite'].settingsAvailable())
 
     has_multiple_nics = lambda a: len(a['network-hardware'].keys()) > 1
 
-    is_reinstall_fn = lambda a: a['install-type'] == constants.INSTALL_TYPE_REINSTALL
+    is_reinstall_fn = lambda a: a['install-type'] == constants.INSTALL_TYPE_UPGRADE
     is_clean_install_fn = lambda a: a['install-type'] == constants.INSTALL_TYPE_FRESH
     is_not_restore_fn = lambda a: a['install-type'] != constants.INSTALL_TYPE_RESTORE
 

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -230,7 +230,7 @@ def get_installation_type(answers):
     entries.append( ("Perform clean installation", None) )
 
     # default value?
-    if 'install-type' in answers and answers['install-type'] == constants.INSTALL_TYPE_REINSTALL:
+    if 'install-type' in answers and answers['install-type'] == constants.INSTALL_TYPE_UPGRADE:
         default = selectDefault(answers['installation-to-overwrite'], entries)
     elif 'install-type' in answers and answers['install-type'] == constants.INSTALL_TYPE_RESTORE:
         default = selectDefault(answers['backup-to-restore'], entries)
@@ -299,7 +299,7 @@ def get_installation_type(answers):
         if 'installation-to-overwrite' in answers:
             del answers['installation-to-overwrite']
     elif isinstance(entry[0], product.ExistingInstallation):
-        answers['install-type'] = constants.INSTALL_TYPE_REINSTALL
+        answers['install-type'] = constants.INSTALL_TYPE_UPGRADE
         answers['installation-to-overwrite'], preservable = entry
         answers['preserve-settings'] = preservable
         if 'primary-disk' not in answers:
@@ -766,7 +766,7 @@ def confirm_installation(answers):
                 term = 'disks'
             disks_used = generalui.makeHumanList(disks)
             text2 = "Please confirm you wish to proceed: all data on %s %s will be destroyed!" % (term, disks_used)
-        elif answers['install-type'] == constants.INSTALL_TYPE_REINSTALL:
+        elif answers['install-type'] == constants.INSTALL_TYPE_UPGRADE:
             if answers['primary-disk'] == answers['installation-to-overwrite'].primary_disk:
                 text2 = "The installation will be performed over %s" % str(answers['installation-to-overwrite'])
             else:


### PR DESCRIPTION
Finding this `INSTALL_TYPE_REINSTALL` hard to read I started to make straight what looked like a simple historic wording.

But then, looking at what that code really does, I'm puzzled, as it seems the "optional backup" code path only exists in the "reinstall" code path in the backend (only used for "upgrade" and not for what is documented as "reinstall" in the doc). And in the TUI the user `backup_existing_installation` is also only called on `is_upgrade_fn`.

Is `<installation mode="reinstall">` really supposed to work as advertised?  A quick test seems to show that it doesn't.  Should it be fixed or disposed of?