### PR TITLE
Remove unused parameters passed to prepareUpgrade

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -373,9 +373,9 @@ class ThirdGenUpgrader(Upgrader):
         finally:
             primary_fs.unmount()
 
-    prepUpgradeArgs = ['installation-uuid', 'control-domain-uuid']
+    prepUpgradeArgs = []
     prepStateChanges = ['installation-uuid', 'control-domain-uuid']
-    def prepareUpgrade(self, progress_callback, installID, controlID):
+    def prepareUpgrade(self, progress_callback):
         """ Try to preserve the installation and control-domain UUIDs from
         xensource-inventory."""
         try:


### PR DESCRIPTION
The two parameters are read from the xensource inventory so no need to pass them as parameters of the prepareUpgrade function.