### PR TITLE
upgrade: restore saved firewall-port plugin state

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -484,6 +484,9 @@ class ThirdGenUpgrader(Upgrader):
         restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
         restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
 
+        # XAPI firewall-port plugin
+        restore_list += ['etc/sysconfig/iptables']
+
         return restore_list
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']


### PR DESCRIPTION
We need this as part of the upgrade of a pool with a linstor SR, where the linstor daemons needs to be able to communicate across the pool when the upgraded host boots anew: the firewall settings that were previously set has to persist.