### PR TITLE
upgrade: allow preserving symbolic links

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -153,7 +153,7 @@ class Upgrader(object):
             if not d: d = f
             src = os.path.join(src_base, f)
             dst = os.path.join(mounts['root'], d)
-            if os.path.exists(src):
+            if os.path.lexists(src):
                 logger.log("Restoring /%s" % f)
                 util.assertDir(os.path.dirname(dst))
                 # copy file/folder and try to preserve all attributes


### PR DESCRIPTION
Subsequent copy_ownership already uses lchown(), there seem to be no reason to check using stat() instead of lstat().

Now (potential) symlinks can be added to restore_list.

One use is to provide ship installed packages with services that are not enabled by default, and to persist their enablement across upgrade.