### PR TITLE
XS9: XSI-1863: Use a disk size of zero if a disk size cannot be determined

### DIFF
--- a/diskutil.py
+++ b/diskutil.py
@@ -284,6 +284,8 @@ def getDiskDeviceSize(dev):
     elif os.path.exists("/sys/block/%s/size" % dev):
         return int(__readOneLineFile__("/sys/block/%s/size" % dev))
 
+    return 0
+
 def getDiskBlockSize(dev):
     if not dev.startswith("/dev/"):
         dev = '/dev/' + dev


### PR DESCRIPTION
getDiskDeviceSize may fail to find the correct disk size, which could lead to the Python default of None being returned - in turn causing larger issues later in the installer where a numeric type is expected.

Matches XS8 PR: https://github.com/xenserver/host-installer/pull/236