### PR TITLE
XSI-1887: Fix upgrade

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -312,7 +312,12 @@ def performInstallation(answers, ui_package, interactive):
     default_host_config = { 'dom0-mem': dom0_mem,
                             'dom0-vcpus': dom0_vcpus,
                             'xen-cpuid-masks': [] }
-    defaults = { 'branding': {}, 'host-config': {}, 'write-boot-entry': True }
+    defaults = {
+        'branding': {},
+        'host-config': {},
+        'write-boot-entry': True,
+        'target-platform': None,
+    }
 
     # update the settings:
     if answers['preserve-settings'] == True:


### PR DESCRIPTION
Due to missing initialisation during a manual upgrade the installer was failing due to missing key in "answers" dictionary. Provides the missing default to avoid the missing key.