### PR TITLE
CP-307868: Boot xen.efi rather than xen.pe

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -956,10 +956,10 @@ def mkinitrd(mounts, primary_disk, primary_partnum):
 def prepFallback(mounts, primary_disk, primary_partnum):
     kernel_version =  getKernelVersion(mounts['root'])
 
-    # Copy /boot/xen-xxxx.pe to /boot/xen-fallback.pe
-    xen_pe = os.path.realpath(mounts['root'] + "/boot/xen.pe")
-    src = os.path.join(mounts['root'], "boot", os.path.basename(xen_pe))
-    dst = os.path.join(mounts['root'], 'boot/xen-fallback.pe')
+    # Copy /boot/xen-xxxx.efi to /boot/xen-fallback.efi
+    xen_efi = os.path.realpath(mounts['root'] + "/boot/xen.efi")
+    src = os.path.join(mounts['root'], "boot", os.path.basename(xen_efi))
+    dst = os.path.join(mounts['root'], 'boot/xen-fallback.efi')
     shutil.copyfile(src, dst)
 
     # Copy /boot/vmlinuz-yyyy to /boot/vmlinuz-fallback
@@ -1016,7 +1016,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
         for interface in fcoe_interfaces:
             common_kernel_params += " fcoe=%s:%s" % (netutil.getHWAddr(interface), 'nodcb' if fcoeutil.hw_lldp_capable(interface) else 'dcb')
 
-    e = bootloader.MenuEntry(hypervisor="/boot/xen.pe",
+    e = bootloader.MenuEntry(hypervisor="/boot/xen.efi",
                              hypervisor_args=' '.join([common_xen_params, common_xen_unsafe_params, xen_mem_params, "console=vga vga=mode-0x0311"]),
                              kernel="/boot/vmlinuz-%s-xen" % short_version,
                              kernel_args=' '.join([common_kernel_params, kernel_console_params, "console=tty0 quiet vga=785 splash plymouth.ignore-serial-consoles"]),
@@ -1027,7 +1027,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
     if serial:
         xen_serial_params = "%s console=%s,vga" % (serial.xenFmt(), serial.port)
 
-        e = bootloader.MenuEntry(hypervisor="/boot/xen.pe",
+        e = bootloader.MenuEntry(hypervisor="/boot/xen.efi",
                                  hypervisor_args=' '.join([xen_serial_params, common_xen_params, common_xen_unsafe_params, xen_mem_params]),
                                  kernel="/boot/vmlinuz-%s-xen" % short_version,
                                  kernel_args=' '.join([common_kernel_params, "console=tty0", kernel_console_params]),
@@ -1036,7 +1036,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
         boot_config.append("xe-serial", e)
         if boot_serial:
             boot_config.default = "xe-serial"
-        e = bootloader.MenuEntry(hypervisor="/boot/xen.pe",
+        e = bootloader.MenuEntry(hypervisor="/boot/xen.efi",
                                  hypervisor_args=' '.join([safe_xen_params, common_xen_params, xen_serial_params]),
                                  kernel="/boot/vmlinuz-%s-xen" % short_version,
                                  kernel_args=' '.join(["earlyprintk=xen", common_kernel_params, "console=tty0", kernel_console_params]),
@@ -1050,7 +1050,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
                             root=constants.rootfs_label%disk_label_suffix)
     boot_config.append("memtest", e)
 
-    e = bootloader.MenuEntry(hypervisor="/boot/xen-fallback.pe",
+    e = bootloader.MenuEntry(hypervisor="/boot/xen-fallback.efi",
                              hypervisor_args=' '.join([common_xen_params, common_xen_unsafe_params, xen_mem_params]),
                              kernel="/boot/vmlinuz-fallback",
                              kernel_args=' '.join([common_kernel_params, kernel_console_params, "console=tty0"]),
@@ -1059,7 +1059,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
                              root=constants.rootfs_label%disk_label_suffix)
     boot_config.append("fallback", e)
     if serial:
-        e = bootloader.MenuEntry(hypervisor="/boot/xen-fallback.pe",
+        e = bootloader.MenuEntry(hypervisor="/boot/xen-fallback.efi",
                                  hypervisor_args=' '.join([xen_serial_params, common_xen_params, common_xen_unsafe_params, xen_mem_params]),
                                  kernel="/boot/vmlinuz-fallback",
                                  kernel_args=' '.join([common_kernel_params, "console=tty0", kernel_console_params]),

--- a/bootloader/grub-usb.patch
+++ b/bootloader/grub-usb.patch
@@ -7,4 +7,4 @@
 +search --file --set /install.img
  
  menuentry "install" {
-     multiboot2 /boot/xen.pe dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+     multiboot2 /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga

--- a/bootloader/grub.cfg
+++ b/bootloader/grub.cfg
@@ -17,25 +17,25 @@ insmod ext2
 set timeout=5
 
 menuentry "install" {
-    multiboot2 /boot/xen.pe dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz console=hvc0 console=tty0
     module2 /install.img
 }
 
 menuentry "no-serial" {
-    multiboot2 /boot/xen.pe dom0_max_vcpus=1-16 dom0_mem=max:8192M console=vga
+    multiboot2 /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M console=vga
     module2 /boot/vmlinuz console=tty0
     module2 /install.img
 }
 
 menuentry "safe" {
-    multiboot2 /boot/xen.pe dom0_max_vcpus=1-16 dom0_mem=max:8192M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep
+    multiboot2 /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep
     module2 /boot/vmlinuz console=hvc0 console=tty0
     module2 /install.img
 }
 
 menuentry "multipath" {
-    multiboot2 /boot/xen.pe dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz console=hvc0 console=tty0 device_mapper_multipath=enabled
     module2 /install.img
 }
@@ -45,14 +45,14 @@ menuentry "memtest" {
 }
 
 menuentry "shell" {
-    multiboot2 /boot/xen.pe dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz console=hvc0 console=tty0 bash-shell
     module2 /install.img
 }
 
 submenu "advanced-options" {
     menuentry "common-criteria-prep" {
-        multiboot2 /boot/xen.pe dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+        multiboot2 /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
         module2 /boot/vmlinuz console=hvc0 console=tty0 cc-preparations
         module2 /install.img
     }


### PR DESCRIPTION
Following an internal discussion, it was decided to use the `xen.efi` name instead of `xen.pe` name.
`efi` extension is the usual extension for EFI applications. `xen.efi` name is the official file name used by upstream Xen. Although currently the file is slightly different from the `xen.efi` use the same name.

Tested building a full ISO and doing manual install.