### PR TITLE
CA-410647: Displaying select network interface should order by name

### DIFF
--- a/tui/network.py
+++ b/tui/network.py
@@ -140,7 +140,7 @@ def select_netif(text, conf, offer_existing=False, default=None):
     """
 
     netifs = list(conf.keys())
-    netifs.sort(key=lambda netif: int(netif[3:]))
+    netifs.sort()
 
     if default not in netifs:
         # find first link that is up


### PR DESCRIPTION
Previous the interfaces are renamed as ethX, thus X is used to order and display the interfaces.
Now the interface names are decided by kernel/systemd, so just order the interface by its name