### PR TITLE
CA-409830: Confirm when overwriting an SR

### DIFF
--- a/diskutil.py
+++ b/diskutil.py
@@ -486,6 +486,10 @@ def log_available_disks():
         if len(dom0disks) == 0:
             logger.log("Unable to find a suitable disk (with a size greater than %dGB) to install to." % constants.min_primary_disk_size)
 
+def isGFS2Filesystem(device):
+    _, out = util.runCmd2(['blkid', '-s', 'TYPE', '-o', 'value', device], with_stdout=True)
+    return out.strip() == 'gfs2'
+
 class Disk:
     def __init__(self, device):
         self.device = device
@@ -499,6 +503,7 @@ class Disk:
 INSTALL_RETAIL = 1
 STORAGE_LVM = 1
 STORAGE_OTHER = 2
+STORAGE_GFS2 = 3
 
 def probeDisk(device):
     """Examines device and reports the apparent presence of a XenServer installation and/or related usage
@@ -509,14 +514,14 @@ def probeDisk(device):
         boot is a tuple of True or False and the partition device
         root is a tuple of None or INSTALL_RETAIL and the partition device
         state is a tuple of True or False and the partition device
-        storage is a tuple of None, STORAGE_LVM or STORAGE_OTHER and the partition device
+        storage is a tuple of None, STORAGE_LVM, STORAGE_GFS2 or STORAGE_OTHER and the partition device
         logs is a tuple of True or False and the partition device
         swap is a tuple of True or False and the partition device
     """
 
     logger.debug("probeDisk(%r)", device)
     disk = Disk(device)
-    possible_srs = []
+    possible_srs = set()
 
     tool = PartitionTool(device)
     tool.dump()
@@ -537,12 +542,11 @@ def probeDisk(device):
                 disk.state = (True, part_device)
                 if num + 2 in tool.partitions:
                     # George Retail and earlier didn't use the correct id for SRs
-                    possible_srs = [num+2]
+                    possible_srs.add(tool._partitionDevice(num + 2))
             elif label and label.startswith(constants.logsfs_label_prefix):
                 disk.logs = (True, part_device)
         elif part['id'] == tool.ID_LINUX_LVM:
-            if num not in possible_srs:
-                possible_srs.append(num)
+            possible_srs.add(part_device)
         elif part['id'] == tool.ID_LINUX_SWAP:
             disk.swap = (True, part_device)
         elif part['id'] == GPTPartitionTool.ID_EFI_BOOT or part['id'] == GPTPartitionTool.ID_BIOS_BOOT:
@@ -550,10 +554,12 @@ def probeDisk(device):
         else:
             logger.info("part %s has unknown id: %s", num, part)
 
-    lv_tool = len(possible_srs) and LVMTool()
-    for num in possible_srs:
-        part_device = tool._partitionDevice(num)
+    # The entire device may be used as an SR unpartitioned
+    if len(list(tool.items())) == 0:
+        possible_srs.add(device)
 
+    lv_tool = len(possible_srs) and LVMTool()
+    for part_device in possible_srs:
         if lv_tool.isPartitionConfig(part_device):
             disk.state = (True, part_device)
         elif lv_tool.isPartitionSR(part_device):
@@ -562,6 +568,8 @@ def probeDisk(device):
                 disk.storage = (STORAGE_OTHER, part_device)
             else:
                 disk.storage = (STORAGE_LVM, part_device)
+        elif isGFS2Filesystem(part_device):
+            disk.storage = (STORAGE_GFS2, part_device)
 
     logger.log('Probe of %s found boot=%s root=%s disk.state=%s storage=%s logs=%s' %
                   (device, str(disk.boot), str(disk.root), str(disk.state), str(disk.storage), str(disk.logs)))

--- a/diskutil.py
+++ b/diskutil.py
@@ -558,6 +558,7 @@ def probeDisk(device):
     if len(list(tool.items())) == 0:
         possible_srs.add(device)
 
+    srs = []
     lv_tool = len(possible_srs) and LVMTool()
     for part_device in possible_srs:
         if lv_tool.isPartitionConfig(part_device):
@@ -565,11 +566,17 @@ def probeDisk(device):
         elif lv_tool.isPartitionSR(part_device):
             pv = lv_tool.deviceToPVOrNone(part_device)
             if pv is not None and pv['vg_name'].startswith(lv_tool.VG_OTHER_SR_PREFIX):
-                disk.storage = (STORAGE_OTHER, part_device)
+                srs.append((STORAGE_OTHER, part_device))
             else:
-                disk.storage = (STORAGE_LVM, part_device)
+                srs.append((STORAGE_LVM, part_device))
         elif isGFS2Filesystem(part_device):
-            disk.storage = (STORAGE_GFS2, part_device)
+            srs.append((STORAGE_GFS2, part_device))
+
+    if len(srs) > 1:
+        logger.info(f'Probe of {device} found multiple SRs: {srs}')
+        raise Exception(f'Cannot handle multiple SRs on a device: {device}')
+    elif srs:
+        disk.storage = srs[0]
 
     logger.log('Probe of %s found boot=%s root=%s disk.state=%s storage=%s logs=%s' %
                   (device, str(disk.boot), str(disk.root), str(disk.state), str(disk.storage), str(disk.logs)))

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -545,13 +545,24 @@ def disk_more_info(context):
 def sorted_disk_list(): # Smallest to largest, then alphabetical
     return sorted(diskutil.getQualifiedDiskList(), key=lambda disk: (len(disk), disk))
 
+def confirm_disk_erase(disk):
+    sr_overwrite_msg = """The selected disk, {}, contains a storage repository. The storage repository may currently be used by other hosts.
+
+Selecting Yes will permanently erase the storage repository and any virtual machine disks it contains.
+
+Are you sure you want to continue?"""
+
+    return snackutil.ButtonChoiceWindowEx(tui.screen,
+        "Confirm Disk Erasure",
+        sr_overwrite_msg.format(diskutil.getHumanDiskLabel(disk, short=True)),
+        ['Yes', 'No'], default=1)
+
 # select drive to use as the Dom0 disk:
 def select_primary_disk(answers):
     button = None
     diskEntries = sorted_disk_list()
 
     entries = []
-    target_is_sr = {}
     min_primary_disk_size = constants.min_primary_disk_size
 
     for de in diskEntries:
@@ -561,11 +572,6 @@ def select_primary_disk(answers):
                        (de, diskutil.blockSizeToGBSize(size), min_primary_disk_size))
             continue
 
-        # determine current usage
-        target_is_sr[de] = False
-        disk = diskutil.probeDisk(de)
-        if disk.storage[0]:
-            target_is_sr[de] = True
         e = (diskutil.getHumanDiskLabel(de), de)
         entries.append(e)
 
@@ -597,13 +603,16 @@ You may need to change your system settings to boot from this disk.""" % (MY_PRO
 
     tui.screen.popHelpLine()
 
-    # entry contains the 'de' part of the tuple passed in
-    answers['primary-disk'] = entry
-
-    if 'installation-to-overwrite' in answers:
-        answers['target-is-sr'] = target_is_sr[answers['primary-disk']]
-
     if button == 'back': return LEFT_BACKWARDS
+
+    # entry contains the 'de' part of the tuple passed in
+    # determine current usage
+    disk = diskutil.probeDisk(entry)
+    if disk.storage[0]:
+        if confirm_disk_erase(entry) == 'no':
+            return REPEAT_STEP
+
+    answers['primary-disk'] = entry
 
     # Warn the user if a utility partition is detected. Give them option to
     # cancel the install.
@@ -696,6 +705,16 @@ def select_guest_disks(answers):
     button = buttons.buttonPressed(rc)
 
     if button == 'back': return LEFT_BACKWARDS
+
+    for i in cbt.getSelection():
+        # The user has already confirmed the primary disk
+        if i == answers['primary-disk']:
+            continue
+
+        disk = diskutil.probeDisk(i)
+        if disk.storage[0]:
+            if confirm_disk_erase(i) == 'no':
+                return REPEAT_STEP
 
     answers['guest-disks'] = cbt.getSelection()
     answers['sr-on-primary'] = answers['primary-disk'] in answers['guest-disks']

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -530,13 +530,6 @@ def disk_more_info(context):
         usage = "%s installation" % MY_PRODUCT_BRAND
     elif disk.storage[0]:
         usage = 'VM storage'
-    else:
-        # Determine disk is being used as an LVM SR with no partitioning
-        rv, out = util.runCmd2([ 'pvs', context, '-o', 'vg_name', '--noheadings' ], with_stdout=True)
-        if rv == 0:
-            vg_name = out.strip()
-            if vg_name.startswith('VG_XenStorage-'):
-                usage = 'VM Storage'
 
     tui.update_help_line([' ', ' '])
     snackutil.TableDialog(tui.screen, "Details", ("Disk:", diskutil.getHumanDiskName(context)),


### PR DESCRIPTION
Add a confirmation dialog to confirm when the user selects a disk that contain an SR since it may result in data being lost.

It applies to the primary disk selection and the guest disk selection.

At the same time, drop the code related to "target-is-sr" since it did determine whether the target is an SR but didn't do anything with the information.

The dialog looks like this:

![sr](https://github.com/user-attachments/assets/af5fb576-5b8e-4f82-8a29-887dc3202c9c)
