### PR TITLE
Upgrade with deprecation of interface-rename

### DIFF
--- a/netutil.py
+++ b/netutil.py
@@ -371,3 +371,13 @@ def disable_ipv6_module(root):
     dv6fd.write("alias net-pf-10 off\n")
     dv6fd.close()
 
+
+from xcp.net.ifrename.dynamic import DynamicRules
+
+def net_devs_of_last_boot(file_path):
+    dynamic_rules = DynamicRules(file_path)
+    if not dynamic_rules.load_and_parse():
+        LOG.warning(f"Failed to parse the interface-rename dynamic rules.")
+        return None
+    else:
+        return [(d.tname, d.mac.as_string(sep=":")) for d in dynamic_rules.lastboot]

--- a/product.py
+++ b/product.py
@@ -268,9 +268,20 @@ class ExistingInstallation:
                 if not d.get('interfaces') and 'parent' in d:
                     p = fetchIfaceInfoFromNetworkdbAsDict(d['parent'])
                     d['interfaces'] = p['interfaces']
+                    d['hwaddrs'] = p.get('hwaddrs')
 
                 results['net-admin-bridge'] = mgmt_iface
-                results['net-admin-interface'] = d.get('interfaces').split(',')[0]
+                hwaddrs = d.get('hwaddrs')
+                if hwaddrs:
+                    net_admin_ifaces = []
+                    nics = [(name, netutil.getHWAddr(name)) for name in netutil.getNetifList()]
+                    for mac in hwaddrs.lower().split(','):
+                        net_admin_ifaces += [name for (name, hwaddr) in nics if mac == hwaddr]
+                    if len(net_admin_ifaces) == 0:
+                        raise SettingsNotAvailable("Could not find any net admin interface")
+                    results['net-admin-interface'] = net_admin_ifaces[0]
+                else:
+                    results['net-admin-interface'] = d.get('interfaces').split(',')[0]
 
                 if_hwaddr = netutil.getHWAddr(results['net-admin-interface'])
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -503,12 +503,6 @@ class ThirdGenUpgrader(Upgrader):
         print("UPGRADE=true", file=state)
         state.close()
 
-        # The existence of the static-rules.conf is used to detect upgrade from Boston or newer
-        if os.path.exists(os.path.join(mounts['root'], 'etc/sysconfig/network-scripts/interface-rename-data/static-rules.conf')):
-            # CA-82901 - convert any old style ppn referenced to new style ppn references
-            util.runCmd2(['sed', r's/pci\([0-9]\+p[0-9]\+\)/p\1/g', '-i',
-                          os.path.join(mounts['root'], 'etc/sysconfig/network-scripts/interface-rename-data/static-rules.conf')])
-
         net_dict = util.readKeyValueFile(os.path.join(mounts['root'], 'etc/sysconfig/network'))
         if net_dict.get('NETWORKING_IPV6', 'no') == 'no':
             nfd = open(os.path.join(mounts['root'], 'etc/sysconfig/network'), 'a')

--- a/upgrade.py
+++ b/upgrade.py
@@ -487,6 +487,34 @@ class ThirdGenUpgrader(Upgrader):
         return restore_list
 
     completeUpgradeArgs = ['mounts', 'installation-to-overwrite', 'primary-disk', 'backup-partnum', 'logs-partnum', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration']
+
+    def convert_interface_rename_data(self, src_file_path, dest_file_path):
+        """
+        Convert data of interface-rename to the data consumed by networkd.
+        """
+        net_devs = netutil.net_devs_of_last_boot(src_file_path)
+        if net_devs is None:
+            logger.error('Failed to parse the interface-rename dynamic rules.')
+            return False
+        else:
+            pattern = r'eth(\d+)'
+            lines = []
+            for (name, mac) in net_devs:
+                match = re.search(pattern, name)
+                if match:
+                    position = match.group(1)
+                    line = f"{position}:mac=\"{mac}\"\n"
+                    logger.log(f"Converted interface-rename data: {line}")
+                    lines += line
+                else:
+                    logger.error(f'Network device name {name} is not like ethN.')
+                    return False
+
+            with open(dest_file_path, mode='w', encoding='utf-8') as f:
+                f.writelines(lines)
+
+            return True
+
     def completeUpgrade(self, mounts, prev_install, target_disk, backup_partnum, logs_partnum, admin_iface, admin_bridge, admin_config):
 
         util.assertDir(os.path.join(mounts['root'], "var/lib/xcp"))
@@ -502,6 +530,24 @@ class ThirdGenUpgrader(Upgrader):
         state = open(os.path.join(mounts['root'], constants.FIRSTBOOT_DATA_DIR, 'host.conf'), 'w')
         print("UPGRADE=true", file=state)
         state.close()
+
+        interface_rename_dir = os.path.join(
+            mounts['root'],
+            'etc/sysconfig/network-scripts/interface-rename-data/'
+        )
+        src_file_path = os.path.join(interface_rename_dir, 'dynamic-rules.json')
+        dest_file_path = os.path.join(
+            mounts['root'],
+            constants.FIRSTBOOT_DATA_DIR,
+            'initial_network_device_rules.conf'
+        )
+        if os.path.exists(src_file_path):
+            if self.convert_interface_rename_data(src_file_path, dest_file_path):
+                logger.log(f'Removing {interface_rename_dir} ...')
+                shutil.rmtree(interface_rename_dir)
+            else:
+                logger.error('Cannot convert interface-rename data.')
+                raise RuntimeError('Cannot convert interface-rename data.')
 
         net_dict = util.readKeyValueFile(os.path.join(mounts['root'], 'etc/sysconfig/network'))
         if net_dict.get('NETWORKING_IPV6', 'no') == 'no':


### PR DESCRIPTION
This PR copes with PR https://github.com/xapi-project/xen-api/pull/6466
The commit 5c4e192 is to resolve the problem when host install is setting up its own networking.
The commit e0ee1e3 is to transform the data of interface-rename to upgraded system.