### PR TITLE
CA-411085: Fix issue of pv name is device link

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -288,7 +288,7 @@ class LVMTool:
         """ Returns the PV record for a given device (partition), or None if there is no PV
         for that device."""
         for pv in self.pvs:
-            if pv['pv_name'] == device:
+            if os.path.samefile(pv['pv_name'], device):
                 return pv
         return None
 
@@ -335,7 +335,8 @@ class LVMTool:
         the volume group that it's in starts with vgPrefix"""
         retVal = None
         for pv in self.pvs:
-            if pv['pv_name'].startswith(devicePrefix) and pv['vg_name'].startswith(vgPrefix):
+            pv_path = os.path.realpath(pv['pv_name'])
+            if pv_path.startswith(devicePrefix) and pv['vg_name'].startswith(vgPrefix):
                 retVal = pv['pv_name']
                 break
         return retVal
@@ -376,7 +377,7 @@ class LVMTool:
         lvsToDelete = []
 
         for pv in self.pvs:
-            if pv['pv_name'] == device:
+            if os.path.samefile(pv['pv_name'], device):
                 pvsToDelete.append(pv['pv_name'])
                 vgsToDelete.append(pv['vg_name'])
 

--- a/diskutil.py
+++ b/diskutil.py
@@ -445,7 +445,7 @@ def findProblematicVGs(disks):
         except:
             # CA-35020: whole disk
             device = pv['pv_name']
-        vgdiskmap[pv['vg_name']].append(device)
+        vgdiskmap[pv['vg_name']].append(os.path.realpath(device))
 
     # for each VG, map the disk list to a boolean list saying whether that
     # disk is in the set we're installing to:


### PR DESCRIPTION
 # pvs ...
  /dev/sda3#VG_XenStorage-54668b23-b850-6876-92c5-9228b5383e3d#11534336#915079692288#915075497984#218172#915095404032

After upgrading to lvm2-2.02.180-18.1.xs8.x86_64.rpm, the pv name becomes device link which is persistent path and is more appropriate to use, so change host installer to handle the case.
 # pvs ...
  /dev/disk/by-id/scsi-36f4ee08067e880002df341f84273b684-part3#VG_XenStorage-54668b23-b850-6876-92c5-9228b5383e3d#11534336#915079692288#915075497984#218172#915095404032