### PR TITLE
CA-411650: Fix disk partition re bug

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -483,13 +483,16 @@ class LVMTool:
         pprint(self.__dict__)
 
 def diskDevice(partitionDevice):
-    matches = re.match(r'(.+)(p?|(-part))\d+$', partitionDevice)
-    if matches:
-        return matches.group(1)
-    matches = re.match(r'(.+\D)\d+$', partitionDevice)
-    if not matches:
-        raise Exception("Could not determine disk device for device '"+partitionDevice+"'")
-    return matches.group(1)
+    # There are three cases:
+    # 1) "p" and a number added, e.g. nvme1n1p3 which happens when the parent device
+    #    ends in a number
+    # 2) "-part" and a number added, e.g. scsi-36f4ee08074d4d5002e3ec9f12273e1c0-part3
+    # 3) Just a number added, e.g. sda3, sdp3
+    m = re.match(r'((?P<case1>.+?\d+)p\d+$)|((?P<case2>.+?)-part\d+$)|((?P<case3>.+\D)\d+$)', partitionDevice)
+    if m:
+        return m.group('case1') or m.group('case2') or m.group('case3')
+
+    raise Exception("Could not determine disk device for device '%s'" % partitionDevice)
 
 def determineMidfix(device):
     DISK_PREFIX = '/dev/'

--- a/diskutil.py
+++ b/diskutil.py
@@ -434,6 +434,7 @@ def getHumanDiskLabel(disk, short=False):
 # groups that will cause a problem if we install XE to those disks:
 def findProblematicVGs(disks):
     real_disks = [os.path.realpath(d) for d in disks]
+    logger.log('Find problematic VGs of disks %s, real paths %s' % (disks, real_disks))
 
     # which disks are the volume groups on?
     vgdiskmap = {}
@@ -452,6 +453,7 @@ def findProblematicVGs(disks):
     vgusedmap = {}
     for vg in vgdiskmap:
         vgusedmap[vg] = [disk in real_disks for disk in vgdiskmap[vg]]
+    logger.log('vgusedmap %s' % vgusedmap)
 
     # now, a VG is problematic if it its vgusedmap entry contains a mixture
     # of True and False.  If it's entirely True or entirely False, that's OK:


### PR DESCRIPTION
The group 1 of `r'(.+)(p?|(-part))\d+$'` does maximum match incorrectly: 
input: scsi-36f4ee08074d4d5002e3ec9f12273e1c0-part3 
output: scsi-36f4ee08074d4d5002e3ec9f12273e1c0-part

Fix the issue, also verify if the disk of output exists.