### PR TITLE
CA-410594: Settle udev after eject

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -12,6 +12,7 @@ import subprocess
 import re
 import gzip
 import shutil
+import time
 from io import BytesIO
 from xml.dom.minidom import parse
 
@@ -584,6 +585,13 @@ class DeviceAccessor(MountingAccessor):
         if self.canEject():
             self.finish()
             util.runCmd2(['eject', self.device])
+
+            # Ejecting causes udev rules to run which can prevent subsequent
+            # operations (e.g. unmounting /dev) to fail with EBUSY.
+            # Therefore, wait a bit for the kernel to fire the rules and then
+            # wait for them to complete before continuing.
+            time.sleep(1)
+            util.runCmd2(util.udevsettleCmd())
 
 class NFSAccessor(MountingAccessor):
     def __init__(self, nfspath):


### PR DESCRIPTION
Calling eject on a CD-ROM causes some udev rules to run. In some cases, the rules will poke /dev and race with the unmount of /dev in writeMachineId() and cause the unmount to fail with EBUSY. The failing unmount is ignored which ends up with /dev being mounted on /tmp/root twice causing the final unmount of /tmp/root to fail (because one instance of /dev is still bind-mounted). Fix this by settling udev after eject() so the system is in a clean state before continuing.