### PR TITLE
CA-400058: Fail if there is no first partition to preserve when requested

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -558,6 +558,8 @@ def partitionTargetDisk(disk, existing, preserve_first_partition, create_sr_part
     # Preserve any utility partitions unless user told us to zap 'em
     primary_part = 1
     if preserve_first_partition == 'true':
+        if tool.getPartition(1):  # If no first partition
+            raise RuntimeError("No first partition to preserve")
         primary_part += 1
     elif preserve_first_partition == constants.PRESERVE_IF_UTILITY:
         utilparts = tool.utilityPartitions()


### PR DESCRIPTION
The previous PR (https://github.com/xenserver/host-installer/pull/198/files) for this improvement assumed that the first partitions are always utility partitions and was hence reverted after internal tests failed

There's no specification or requirement that the first partition is a utility partition, but there is an option (the default) to preserve the first partition if it is a utility partition. This was likely the cause of the confusion