### PR TITLE
CA-412051: Add debug logs for libsystemd-core.so link issue

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -854,10 +854,15 @@ def __mkinitrd(mounts, primary_disk, partition, kernel_version):
     except:
         pass
 
-    cmd = ['dracut', '-f', output_file, kernel_version]
+    cmd = ['dracut', '--verbose', '-f', output_file, kernel_version]
 
     if util.runCmd2(['chroot', mounts['root']] + cmd) != 0:
         raise RuntimeError("Failed to create initrd for %s.  This is often due to using an installer that is not the same version of %s as your installation source." % (kernel_version, MY_PRODUCT_BRAND))
+
+    # CA-412051: debug logging, will revert in future
+    util.runCmd2(['chroot', mounts['root'], 'ldd', '/usr/sbin/init'])
+    util.runCmd2(['chroot', mounts['root'], 'rpm', '-ql', 'systemd'])
+    util.runCmd2(['chroot', mounts['root'], 'lsinitrd', output_file])
 
 def getXenVersion(rootfs_mount):
     """ Return the xen version by interogating the package version in the chroot """


### PR DESCRIPTION
After installation, the following error occurred during startup.

  /init: error while loading shared libraries:
    libsystemd-core-257.2-5.xs9.so: cannot open shared object file:
    No such file or directory

This problem is extremely difficult to reproduce, so added debug logs, and which will be reverted in future.