### PR TITLE
CP-307931 Remove unused net-admin-interface key

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -176,14 +176,14 @@ def getFinalisationSequence(ans):
         Task(writeResolvConf, A(ans, 'mounts', 'manual-hostname', 'manual-nameservers'), []),
         Task(writeMachineID, A(ans, 'mounts'), []),
         Task(writeKeyboardConfiguration, A(ans, 'mounts', 'keymap'), []),
-        Task(configureNetworking, A(ans, 'mounts', 'net-admin-interface', 'net-admin-bridge', 'net-admin-configuration', 'manual-hostname', 'manual-nameservers', 'network-hardware', 'preserve-settings', 'network-backend'), []),
+        Task(configureNetworking, A(ans, 'mounts', 'net-admin-interface', 'net-admin-configuration', 'manual-hostname', 'manual-nameservers', 'network-hardware', 'preserve-settings', 'network-backend'), []),
         Task(prepareSwapfile, A(ans, 'mounts', 'primary-disk', 'swap-partnum', 'disk-label-suffix'), []),
         Task(writeFstab, A(ans, 'mounts', 'primary-disk', 'logs-partnum', 'swap-partnum', 'disk-label-suffix', 'fs-type'), []),
         Task(enableAgent, A(ans, 'mounts', 'network-backend', 'services'), []),
         Task(configureCC, A(ans, 'mounts'), []),
         Task(writeInventory, A(ans, 'installation-uuid', 'control-domain-uuid', 'mounts', 'primary-disk',
                                'backup-partnum', 'logs-partnum', 'boot-partnum', 'swap-partnum', 'storage-partnum',
-                               'guest-disks', 'net-admin-bridge',
+                               'guest-disks',
                                'branding', 'net-admin-configuration', 'host-config', 'install-type'), []),
         Task(writeXencommons, A(ans, 'control-domain-uuid', 'mounts'), []),
         Task(configureISCSI, A(ans, 'mounts', 'primary-disk'), []),
@@ -342,15 +342,6 @@ def performInstallation(answers, ui_package, interactive):
             answers['host-config'][k] = v
     logger.log("UPDATED ANSWERS DICTIONARY:")
     prettyLogAnswers(answers)
-
-    # Slight hack: we need to write the bridge name to xensource-inventory
-    # further down; compute it here based on the admin interface name if we
-    # haven't already recorded it as part of reading settings from an upgrade:
-    if answers['install-type'] == INSTALL_TYPE_FRESH:
-        answers['net-admin-bridge'] = ''
-    elif 'net-admin-bridge' not in answers:
-        assert answers['net-admin-interface'].startswith("eth")
-        answers['net-admin-bridge'] = "xenbr%s" % answers['net-admin-interface'][3:]
 
     # perform installation:
     prep_seq = getPrepSequence(answers, interactive)
@@ -1382,7 +1373,7 @@ def setRootPassword(mounts, root_pwd):
         assert pipe.wait() == 0
 
 # write /etc/sysconfig/network-scripts/* files
-def configureNetworking(mounts, admin_iface, admin_bridge, admin_config, hn_conf, ns_conf, nethw, preserve_settings, network_backend):
+def configureNetworking(mounts, admin_iface, admin_config, hn_conf, ns_conf, nethw, preserve_settings, network_backend):
     """ Writes configuration files that the firstboot scripts will consume to
     configure interfaces via the CLI.  Writes a loopback device configuration.
     to /etc/sysconfig/network-scripts, and removes any other configuration
@@ -1458,7 +1449,7 @@ def writeXencommons(controlID, mounts):
         f.write(contents)
 
 def writeInventory(installID, controlID, mounts, primary_disk, backup_partnum, logs_partnum, boot_partnum, swap_partnum,
-                   storage_partnum, guest_disks, admin_bridge, branding, admin_config, host_config, install_type):
+                   storage_partnum, guest_disks, branding, admin_config, host_config, install_type):
     inv = open(os.path.join(mounts['root'], constants.INVENTORY_FILE), "w")
     if 'product-brand' in branding:
        inv.write("PRODUCT_BRAND='%s'\n" % branding['product-brand'])


### PR DESCRIPTION
There is hard code "eth" in converting interface name to bridge name. It is incorrect after dropping interface-rename. As host-installer needn't write management-interface to inventory any more (see https://github.com/xenserver/host-installer/pull/238), the net-admin-bridge generating code and related parameters can be removed. 