### PR TITLE
CA-413195: Fixed parsing pci data issue

### DIFF
--- a/dmvutil.py
+++ b/dmvutil.py
@@ -169,6 +169,8 @@ def parsePCIData(pcilist):
         \s*
         (?:-(?P<revision>\S+))?      # Optional revision (-r06)
         \s*
+        (?:-(?P<progif>\S+))?        # Optional programming interface (-p00)
+        \s*
         (?: "(?P<subvendor>[^"]*)")? # Optional subvendor (Dell)
         \s*
         (?: "(?P<subdevice>[^"]*)")? # Optional subdevice (Device abcd)
@@ -182,7 +184,6 @@ def parsePCIData(pcilist):
             devclass = pci_info["class"]
             vendor_id = pci_info["vendor"]
             device_id = filterDeviceRev(pci_info["device"])
-            rev = pci_info["revision"]
 
             driver = readPciDriver(pci_slot)
             if driver:


### PR DESCRIPTION
Previously, function parsePCIData only matched 7 fields of the output of lspci, however, in some machines, there are 8 fields. Then it would cause error if no output matched.
Added the missing optional field in the regex expression.

Tested:
Tested: 4353004, 4353000
The installation succeeded.