### PR TITLE
CA-413319 Preserve console timeout configuration during upgrade

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -470,6 +470,9 @@ class ThirdGenUpgrader(Upgrader):
         # CP-42523: NRPE service config
         restore_list += ['etc/nagios/nrpe.cfg', {'dir': 'etc/nrpe.d'}]
 
+        # CA-413319 Preserve console timeout config
+        restore_list += ['etc/profile.d/console_timeout.sh']
+
         # CP-44441: SNMP service config
         # From XS 8.4 SNMP feature is supported, and new file /etc/snmp/snmp.xs.conf is added
         # into dom0, the file can be treated as the feature flag. Host installer must not


### PR DESCRIPTION
Preserve console timeout config when upgrade from XS8 to XS9.
(Note: this configuration file may not exist if the user has not configured it via an XAPI call. but, the code [https://github.com/xenserver/host-installer/blob/master/upgrade.py#L156] includes protection for non-existing files, so it is safe to add this configuration to **restore_list**)