### PR TITLE
Give a more explicit message when Yum gets killed

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -834,7 +834,10 @@ def installFromYum(targets, mounts, progress_callback, cachedir):
             logger.log("YUM stderr: %s" % stderr.strip())
 
         if rv:
-            logger.log("Yum exited with %d" % rv)
+            if rv > 0:
+                logger.log("Yum exited with %d" % rv)
+            else:
+                logger.log("Yum killed by signal %d" % -rv)
             raise ErrorInstallingPackage("Error installing packages")
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))


### PR DESCRIPTION
This is a backport for xs8 of #271 but without translating signal number to name, since that function comes with python3