### PR TITLE
[XS8] upgrade: allow preserving symbolic links

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -183,7 +183,7 @@ class Upgrader(object):
             if not d: d = f
             src = os.path.join(src_base, f)
             dst = os.path.join(mounts['root'], d)
-            if os.path.exists(src):
+            if os.path.lexists(src):
                 logger.log("Restoring /%s" % f)
                 util.assertDir(os.path.dirname(dst))
                 # copy file/folder and try to preserve all attributes


### PR DESCRIPTION
This is a backport of #235 

Subsequent copy_ownership already uses lchown(), there seem to be no reason to check using stat() instead of lstat().

Now (potential) symlinks can be added to restore_list.

(cherry picked from commit dca39d4c6a5289aa3a83c9b4348efa15a7aa8d8b)