### PR TITLE
CP-53110: Put driver disk feature behind a feature flag

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -180,6 +180,7 @@ INIT_SERVICE_FILES = [
 # optional features
 FEATURES_DIR = "/etc/xensource/features"
 HAS_SUPPLEMENTAL_PACKS = os.path.exists(os.path.join(FEATURES_DIR, "supplemental-packs"))
+HAS_DRIVER_DISKS = os.path.exists(os.path.join(FEATURES_DIR, "driver-disks"))
 SR_TYPE_LARGE_BLOCK = None
 try:
     with open(os.path.join(FEATURES_DIR, "large-block-capable-sr-type")) as f:

--- a/doc/features.txt
+++ b/doc/features.txt
@@ -15,6 +15,13 @@ Currently available feature flags are:
     This only impacts the UI, the <source> answerfile construct still
     allows to include supplemental packs without this feature flag.
 
+  driver-disks
+
+    Allows users to load additional drivers in the installer environment.
+    - When enabled, an <F9> hotkey will appear on the welcome screen
+    to access this feature.
+    - When disabled, the hotkey and related UI will not be shown.
+
   large-block-capable-sr-type
 
     Allow the use of an SR type for local storage that (unlike "lvm" and

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -46,7 +46,8 @@ def selectDefault(key, entries):
 def welcome_screen(answers):
     driver_answers = {'driver-repos': []}
 
-    tui.update_help_line([None, "<F9> load driver"])
+    if constants.HAS_DRIVER_DISKS:
+        tui.update_help_line([None, "<F9> load driver"])
 
     def load_driver(driver_answers):
         tui.screen.popHelpLine()
@@ -70,17 +71,22 @@ def welcome_screen(answers):
     while loop:
         loop = False
         driver_answers['network-hardware'] = answers['network-hardware'] = netutil.scanConfiguration()
+        welcome_text = """This setup tool can be used to install or upgrade %s on your system or restore your server from backup.  Installing %s will erase all data on the disks selected for use.
+
+Please make sure you have backed up any data you wish to preserve before proceeding.
+""" % (MY_PRODUCT_BRAND, MY_PRODUCT_BRAND)
+        if constants.HAS_DRIVER_DISKS:
+            welcome_text += "\nTo load a device driver press <F9>.\n"
+
+        hotkeys = {}
+        if constants.HAS_DRIVER_DISKS:
+            hotkeys = {'F9': fn9}
 
         button = snackutil.ButtonChoiceWindowEx(tui.screen,
                                 "Welcome to %s Setup" % MY_PRODUCT_BRAND,
-                                """This setup tool can be used to install or upgrade %s on your system or restore your server from backup.  Installing %s will erase all data on the disks selected for use.
-
-Please make sure you have backed up any data you wish to preserve before proceeding.
-
-To load a device driver press <F9>.
-""" % (MY_PRODUCT_BRAND, MY_PRODUCT_BRAND),
+                                welcome_text,
                                 ['Ok', 'Reboot'], width=60, help="welcome",
-                                hotkeys={'F9': fn9})
+                                hotkeys=hotkeys)
         if loop:
             load_driver(driver_answers)
             tui.update_help_line([None, "<F9> load driver"])

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -26,7 +26,6 @@ import tui
 import tui.network
 import tui.progress
 import driver
-import tui.fcoe
 
 from netinterface import NetInterface
 
@@ -61,26 +60,15 @@ def welcome_screen(answers):
         return True
 
     global loop
-    global popup
     loop = True
 
     def fn9():
         global loop
-        global popup
         loop = True
-        popup = 'driver'
-        return False
-
-    def fn10():
-        global loop
-        global popup
-        loop = True
-        popup = 'storage'
         return False
 
     while loop:
         loop = False
-        popup = None
         driver_answers['network-hardware'] = answers['network-hardware'] = netutil.scanConfiguration()
 
         button = snackutil.ButtonChoiceWindowEx(tui.screen,
@@ -90,15 +78,11 @@ def welcome_screen(answers):
 Please make sure you have backed up any data you wish to preserve before proceeding.
 
 To load a device driver press <F9>.
-To setup advanced storage classes press <F10>.
 """ % (MY_PRODUCT_BRAND, MY_PRODUCT_BRAND),
                                 ['Ok', 'Reboot'], width=60, help="welcome",
-                                hotkeys={'F9': fn9, 'F10': fn10})
-        if popup == 'driver':
+                                hotkeys={'F9': fn9})
+        if loop:
             load_driver(driver_answers)
-            tui.update_help_line([None, "<F9> load driver"])
-        elif popup == 'storage':
-            tui.fcoe.select_fcoe_ifaces(answers)
             tui.update_help_line([None, "<F9> load driver"])
 
     tui.screen.popHelpLine()


### PR DESCRIPTION
- Hide driver disk feature behind a feature flag
- Remove FCoE configuration from the welcome screen
Full FCoE removal will be completed in a follow-up.