### PR TITLE
CA-414146: Fix restore partnum identification

### DIFF
--- a/restore.py
+++ b/restore.py
@@ -25,7 +25,7 @@ def restoreFromBackup(backup, progress=lambda x: ()):
     tool = PartitionTool(disk)
     dsk = diskutil.probeDisk(disk)
     create_sr_part = dsk.storage[0] is not None
-    boot_partnum, primary_partnum, backup_partnum, logs_partnum, swap_partnum, _ = backend.partitionTargetDisk(disk, None, constants.PRESERVE_IF_UTILITY, create_sr_part)
+    primary_partnum, backup_partnum, _, boot_partnum, logs_partnum, swap_partnum = backend.partitionTargetDisk(disk, None, constants.PRESERVE_IF_UTILITY, create_sr_part)
 
     backup_fs = util.TempMount(backup.partition, 'backup-', options=['ro'])
     inventory = util.readKeyValueFile(os.path.join(backup_fs.mount_point, constants.INVENTORY_FILE), strip_quotes=True)


### PR DESCRIPTION
677583e7d0aefe57feb5506284ff4c608aec99dc changed the order of the partition numbers returned by backend.partitionTargetDisk
Although there is a comment saying it shouldn't be used for restore, it was already being used and we should update references to it when the original change was made.
Currently restore fails with fresh installations+upgrades as it confuses the primary partition with the backup partition, leading to an attempt to wipe a mounted partition