### PR TITLE
CP-308812 Add new Answerfile label ssh-mode to control SSH status

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -138,6 +138,7 @@ class Answerfile:
         results.update(self.parseNSConfig())
         self.parseTimeConfig(results)
         results.update(self.parseKeymap())
+        results.update(self.parseSSHMode())
         results.update(self.parseServices())
 
         return results
@@ -503,6 +504,17 @@ class Answerfile:
         nodes = getElementsByTagName(self.top_node, ['ui-confirmation-prompt'])
         if len(nodes) > 0:
             results['ui-confirmation-prompt'] = bool(getText(nodes[0]))
+        return results
+
+    def parseSSHMode(self):
+        results = {}
+        nodes = getElementsByTagName(self.top_node, ['ssh-mode'])
+        if len(nodes) > 0:
+            ssh_mode = getText(nodes[0]).lower()
+            if ssh_mode not in ('on', 'off', 'auto'):
+                logger.log("Invalid ssh-mode %s specified in answerfile." % ssh_mode)
+                ssh_mode = None
+            results['ssh-mode'] = ssh_mode
         return results
 
     def parseServices(self):

--- a/install.py
+++ b/install.py
@@ -103,6 +103,7 @@ def go(ui, args, answerfile_address, answerfile_script):
         'services': { s: None for s in constants.SERVICES }, # default state for services, example {'sshd': None}
         'preserve-first-partition': constants.PRESERVE_IF_UTILITY,
         'fs-type': constants.default_rootfs_type,
+        'ssh-mode': None,  # default SSH mode (no specific configuration)
         }
     suppress_extra_cd_dialog = False
     serial_console = None


### PR DESCRIPTION
Add a new answerfile label `<ssh-mode>on/off/auto</ssh-mode>` to control SSH auto-mode behavior and SSH service status:

- `<ssh-mode>on</ssh-mode>`: Disables auto-mode and enables SSH by default
- `<ssh-mode>off</ssh-mode>`: Disables auto-mode and disables SSH by default
- `<ssh-mode>auto</ssh-mode>`: Enables auto-mode and stops SSH once XAPI starts up