### PR TITLE
CA-416373: virtual interface name exceed the limitation

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -160,6 +160,11 @@ MPATH_ISCSI_TIMEOUT = 15
 
 ISCSI_NODES = 'var/lib/iscsi/nodes'
 
+# interface length limitation from linux kernel (16-1), refer to dev_valid_name in kernel source
+INTERFACE_NAME_LENGTH_MAX = 15
+# max length of vlan ID
+VLAN_LENGTH_MAX = 4
+
 # prepare configuration for common criteria security
 CC_PREPARATIONS = False
 CC_FIREWALL_CONF = '/opt/xensource/installer/common_criteria_firewall_rules'

--- a/init
+++ b/init
@@ -74,8 +74,6 @@ def configureNetworking(ui, device, config):
             iface_to_start.append(devname)
 
     for i in iface_to_start:
-        netutil.ifup(netcfg[i].getInterfaceName(i))
-        netcfg[i].waitUntilUp(i)
         netcfg[i].writeSystemdNetworkdConfig(i)
 
     # Reload network to apply the configuration

--- a/netinterface.py
+++ b/netinterface.py
@@ -5,7 +5,10 @@ import configparser
 
 import util
 import netutil
+import random
+import string
 from xcp import logger
+import constants
 
 def getText(nodelist):
     rc = ""
@@ -13,12 +16,16 @@ def getText(nodelist):
         if node.nodeType == node.TEXT_NODE:
             rc = rc + node.data
     return rc.strip().encode()
+
 def getTextOrNone(nodelist):
     rc = ""
     for node in nodelist:
         if node.nodeType == node.TEXT_NODE:
             rc = rc + node.data
     return rc == "" and None or rc.strip().encode()
+
+def random_string(size=10):
+    return "".join(random.choices(string.ascii_letters, k=size))
 
 
 class CaseConfigParser(configparser.ConfigParser):
@@ -107,7 +114,18 @@ class NetInterface:
         return retval
 
     def getInterfaceName(self, iface):
-        return ("%s.%d" % (iface, self.vlan)) if self.vlan else iface
+        if not self.vlan:
+            return iface
+
+        # linux kernel has limitation for the interface name length, 1 for the "." in the middle
+        max_host_interface_length = constants.INTERFACE_NAME_LENGTH_MAX - constants.VLAN_LENGTH_MAX - 1;
+        if len(iface) <= max_host_interface_length:
+            return f"{iface}.{self.vlan}"
+        else:
+            name = f"{random_string(max_host_interface_length)}.{self.vlan}"
+            logger.log(f"Generated {name} for {iface}.{self.vlan}")
+            return name
+
 
     def addIPv6(self, modev6, ipv6addr=None, ipv6gw=None):
         assert modev6 is None or modev6 == self.Static or modev6 == self.DHCP or modev6 == self.Autoconf
@@ -162,7 +180,7 @@ class NetInterface:
         sysd_netd_path = "/etc/systemd/network"
         iface_vlan = self.getInterfaceName(iface)
 
-        logger.debug(f"Configuring {iface} with systemd-networkd")
+        logger.log(f"Configuring {iface} with systemd-networkd")
 
         network_conf = CaseConfigParser()
         # Match section, match by Name
@@ -213,7 +231,7 @@ class NetInterface:
                     f.write(f"VLAN={iface_vlan}\n")
             else:
                 # The hosting interface just used to host the vlan
-                logger.debug("Found vlan {iface_vlan} with unconfigured hosting interface")
+                logger.log(f"Found vlan {iface_vlan} with unconfigured hosting interface")
                 hosting_conf = CaseConfigParser()
                 hosting_conf["Match"] = {}
                 hosting_conf["Match"]["Name"] = iface


### PR DESCRIPTION
Linux kernel limit the interface name length to 16(exclude), refer to dev_valid_name for the details.

The vlan interface name was defined as `host_interface.vlanID`, this was fine when the interface was defined as ethX, but is a problem when systemd provide a long interface name for the host interface.

To resolve the issue, the vlan interface name is normalized to ensure it does not exceed the limitation.

The interface bring up before `networkctl reload` is removed, as `networkctl reload` will bring it up anyway