### PR TITLE
CA-416618: Support degraded SW RAID installations

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -317,11 +317,14 @@ class Answerfile:
         results['swraid'] = getBoolAttribute(node, ['swraid'], default=False)
 
         if results['swraid']:
-            results['primary-disk'] = ""  # Populated with disk-label-suffix during installer prep
-            results['physical-disks'] = [normalize_disk(disk) for disk in getText(node).split(",")]
-
-            if len(results['physical-disks']) != 2:
+            disks = getText(node).split(",")
+            if len(disks) != 2:
                 raise AnswerfileException("swraid primary-disk requires exactly two physical disks")
+            if disks.count("missing") > 1:
+                raise AnswerfileException("swraid primary-disk supports only one missing disk")
+
+            results['primary-disk'] = ""  # Populated with disk-label-suffix during installer prep
+            results['physical-disks'] = [normalize_disk(disk) for disk in disks if disk != "missing"]
         else:
             results['primary-disk'] = normalize_disk(getText(node))
             results['physical-disks'] = [results['primary-disk']]

--- a/backend.py
+++ b/backend.py
@@ -581,10 +581,11 @@ def setupSWRAIDDevice(disk_label_suffix, physical_disks, guest_disks):
     if rc != 0:
         raise RuntimeError("Failed to create SWRAID device: '%s' from initial device: '%s'" % (primary_disk, physical_disks[0]))
 
-    # Add second disk to SW RAID device
-    rc = util.runCmd2(['mdadm', '--manage', primary_disk, '--add', physical_disks[1], '--run'])
-    if rc != 0:
-        raise RuntimeError("Failed to add second disk: '%s' to SWRAID device: '%s'" % (physical_disks[1], primary_disk))
+    if len(physical_disks) == 2:
+        # Add second disk to SW RAID device
+        rc = util.runCmd2(['mdadm', '--manage', primary_disk, '--add', physical_disks[1], '--run'])
+        if rc != 0:
+            raise RuntimeError("Failed to add second disk: '%s' to SWRAID device: '%s'" % (physical_disks[1], primary_disk))
 
     with open('/proc/sys/dev/raid/speed_limit_max', 'w') as speed_file:
         speed_file.write(str(constants.swraid_speed_write_max))
@@ -1299,7 +1300,7 @@ def installExtLinux(mounts, disk, location=constants.BOOT_LOCATION_MBR):
 
 def mountVolumes(primary_disk, physical_disks, boot_partnum, primary_partnum, logs_partnum, cleanup, target_boot_mode, swraid):
     if swraid:
-        util.runCmd2(['mdadm', '--assemble', primary_disk, physical_disks[0], physical_disks[1]])
+        util.runCmd2(['mdadm', '--assemble', primary_disk] + physical_disks)
 
     mounter = DeviceMounter()
     mounter.mount()

--- a/doc/answerfile.txt
+++ b/doc/answerfile.txt
@@ -198,6 +198,8 @@ Format of 'source' and 'driver-source'
         of the primary-disk element. Devices should be comma separated.
         The first device will be treated as the original, the second device will
         mirror the first.
+        At most one device may be "missing" to proceed with a degraded RAID
+        device.
 
         The resulting multidevice will be /dev/md/xs-<disk-label-suffix>.
 


### PR DESCRIPTION
During recovery a user may choose to re-install on a single physical disk while the other part of the SW RAID device is in-operable. To achieve this the answerfile must accept a "missing" second physical disk.

Performing upgrade & restore operations over a degraded device is not supported - this use case was requested by the internal customer as part of their reset process; in which a fresh installation will be performed on a single target device