### PR TITLE
CP-308804 / CA-415170: Multipath changes for XS9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ install:
 
  # Generate a multipath configuration from the installed copy, removing
  # the blacklist and blacklist_exception sections.
-	sed 's/\(^[[:space:]]*find_multipaths[[:space:]]*\)yes/\1no/' \
+	sed 's/\(^[[:space:]]*find_multipaths[[:space:]]*\)strict/\1yes/' \
 	    < $(XS_MPATH_CONF) \
 	    > $(DESTDIR)/etc/multipath.conf.disabled
 

--- a/backend.py
+++ b/backend.py
@@ -959,12 +959,8 @@ def kernelShortVersion(version):
 def configureSRMultipathing(mounts, primary_disk):
     # Only called on fresh installs:
     # Configure multipathed SRs iff root disk is multipathed
-    fd = open(os.path.join(mounts['root'], constants.FIRSTBOOT_DATA_DIR, 'sr-multipathing.conf'),'w')
-    if isDeviceMapperNode(primary_disk):
-        fd.write("MULTIPATHING_ENABLED='True'\n")
-    else:
-        fd.write("MULTIPATHING_ENABLED='False'\n")
-    fd.close()
+    with open(os.path.join(mounts['root'], constants.FIRSTBOOT_DATA_DIR, 'sr-multipathing.conf'), 'w') as f:
+        f.write("MULTIPATHING_ENABLED='%s'\n" % (isDeviceMapperNode(primary_disk),))
 
 def adjustISCSITimeoutForFile(path):
     iscsiconf = open(path, 'r')

--- a/bootloader/grub.cfg
+++ b/bootloader/grub.cfg
@@ -19,12 +19,6 @@ menuentry "safe" {
     xen_module /install.img
 }
 
-menuentry "multipath" {
-    xen_hypervisor /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
-    xen_module /boot/vmlinuz console=hvc0 console=tty0 device_mapper_multipath=enabled
-    xen_module /install.img
-}
-
 menuentry "memtest" {
     linux /boot/memtest86+x64.efi
 }

--- a/diskutil.py
+++ b/diskutil.py
@@ -50,7 +50,7 @@ def mpath_enable():
     global use_mpath
     assert 0 == util.runCmd2(['modprobe','dm-multipath'])
 
-    if not os.path.exists('/etc/multipath.conf') and os.path.exists('/etc/multipath.conf.disabled'):
+    if os.path.exists('/etc/multipath.conf.disabled'):
         os.rename('/etc/multipath.conf.disabled', '/etc/multipath.conf')
 
     # launch manually to make possible to wait initialization

--- a/init
+++ b/init
@@ -113,7 +113,7 @@ def main(args):
     reboot = False
     answerfile_address = None
     answerfile_script = None
-    mpath = False
+    mpath = True
     use_ibft = False
     netdev_map = []
 


### PR DESCRIPTION
Fix installer multipathing in XS9 and enable it by default when there are multiple paths available.