### PR TITLE
Remove mcelog configuration

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -205,7 +205,6 @@ def getFinalisationSequence(ans):
         Task(setRootPassword, A(ans, 'mounts', 'root-password'), [], args_sensitive=True),
         Task(setTimeZone, A(ans, 'mounts', 'timezone'), []),
         Task(writei18n, A(ans, 'mounts'), []),
-        Task(configureMCELog, A(ans, 'mounts'), []),
         Task(writeDMVSelections, A(ans, 'mounts', 'selected-multiversion-drivers'), []),
         ]
 
@@ -454,25 +453,6 @@ def performInstallation(answers, ui_package, interactive):
     # complete the installation:
     fin_seq = getFinalisationSequence(answers)
     executeSequence(fin_seq, "Completing installation...", answers, ui_package, True)
-
-def configureMCELog(mounts):
-    """Disable mcelog on unsupported processors."""
-
-    is_amd = False
-    model = 0
-
-    with open('/proc/cpuinfo', 'r') as f:
-        for line in f:
-            line = line.strip()
-            if re.match('vendor_id\s*:\s*AuthenticAMD$', line):
-                is_amd = True
-                continue
-            m = re.match('cpu family\s*:\s*(\d+)$', line)
-            if m:
-                model = int(m.group(1))
-
-    if is_amd and model >= 16:
-        util.runCmd2(['chroot', mounts['root'], 'systemctl', 'disable', 'mcelog'])
 
 def rewriteNTPConf(root, ntp_servers):
     ntpsconf = open("%s/etc/chrony.conf" % root, 'r')


### PR DESCRIPTION
mcelog is no longer part of XS9 and this function currently reports an error.