### PR TITLE
CA-375347: Increase crash kernel memory size to 512MB

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1058,7 +1058,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
     safe_xen_params = ("nosmp noreboot noirqbalance no-mce no-bootscrub "
                        "no-numa no-hap no-mmcfg max_cstate=0 "
                        "nmi=ignore allow_unsafe")
-    xen_mem_params = "crashkernel=256M,below=4G"
+    xen_mem_params = "crashkernel=512M,below=4G"
 
     # CA-103933 - AMD PCI-X Hypertransport Tunnel IOAPIC errata
     rc, out = util.runCmd2(['lspci', '-n'], with_stdout=True)


### PR DESCRIPTION
Currently the crash kernel memory size is 256MB, and it's not enough for crash kernel to boot in some machines with drivers that consume a large amount of memory.