### PR TITLE
Retain trusted TLS certificates in RPU

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -525,6 +525,7 @@ class ThirdGenUpgrader(Upgrader):
         # Preserve pool certificates across upgrades
         restore_list += ['etc/stunnel/xapi-pool-ca-bundle.pem', {'dir': 'etc/stunnel/certs-pool'}]
         restore_list += ['etc/stunnel/xapi-stunnel-ca-bundle.pem', {'dir': 'etc/stunnel/certs'}]
+        restore_list += [{'dir': 'etc/trusted-certs'}]
 
         # XAPI firewall-port plugin
         restore_list += ['etc/sysconfig/iptables']


### PR DESCRIPTION
The XAPI managed trusted TLS certificates will be stored under '/etc/trusted-certs' on dom0 filesystem. These certificates need to be retained during RPU.

It's fine when the directory '/etc/trusted-certs' doesn't exist.