### PR TITLE
installFromYum: give more detailed error messages on gpg errors

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -830,15 +830,43 @@ def installFromYum(targets, mounts, progress_callback, cachedir):
         rv = p.wait()
         stderr.seek(0)
         stderr = stderr.read()
+        gpg_error_message = None
         if stderr:
             logger.log("YUM stderr: %s" % stderr.strip())
+
+            if ' in import_key_to_pubring' in stderr:
+                gpg_error_message = "Signature key import failed"
+            # add any other instance of uncaught GpgmeError before this like
+            elif 'gpgme.GpgmeError: ' in stderr:
+                gpg_error_message = "Cryptography-related yum crash"
+
+            elif re.search("Couldn't open file [^ ]*/repodata/repomd.xml.asc", stderr):
+                # would otherwise be mistaken for "pubring import" !?
+                gpg_error_message = "No signature on repository metadata"
+            elif 'repomd.xml signature could not be verified' in stderr:
+                gpg_error_message = "Repository signature verification failure"
+
+            else:
+                match = re.search("Public key for ([^ ]*.rpm) is not installed", stderr)
+                if match:
+                    gpg_error_message = "Missing key for %s" % (match.group(1),)
+                match = re.search("Package ([^ ]*.rpm) is not signed", stderr)
+                if match:
+                    gpg_error_message = "Package not signed: %s" % (match.group(1),)
+                match = re.search(r" ([^ ]*): \[Errno [0-9]*\] No more mirrors to try", stderr)
+                if match:
+                    # rpm not found or corrupted/re-signed/etc
+                    gpg_error_rpm_not_found = match.group(1)
+                    gpg_error_message = "Cannot find valid rpm for %s" % (match.group(1),)
 
         if rv:
             if rv > 0:
                 logger.log("Yum exited with %d" % rv)
             else:
                 logger.log("Yum killed by signal %d" % -rv)
-            raise ErrorInstallingPackage("Error installing packages")
+            if gpg_error_message is None:
+                gpg_error_message = "Error installing packages"
+            raise ErrorInstallingPackage(gpg_error_message)
 
         shutil.rmtree(os.path.join(mounts['root'], cachedir))
 


### PR DESCRIPTION
This is the xs8 version of #71 currently shipping in XCP-ng 8.3, which will be forward-ported to v9 next

Covers:
1. repo_gpgcheck: a. wrong system clock putting gpg key creation in the future, causing a yum crash (nothing special happens if the date of the signature is in the future ¯\_(ツ)_/¯) b. other yum crashes due to uncaught gpg exceptions (if any) c. lack of repomd signature (while repo_gpgcheck is in force) d. signature done by other key than the one in ISO ("repomd.xml signature could not be verified" ¯\_(ツ)_/¯)
2. gpgcheck: a. RPM signed with unknown key b. unsigned RPM referenced by unsigned repomd (no-repo-gpgcheck) c. RPM re-signed with unknown key, unsigned repomd (no-repo-gpgcheck) d. RPM overwritten with another RPM signed with known key (diagnosed through hash but, same diag as 2.c) e. delsigned/resigned/etc RPM, unchanged repomd (same diag as 2.c/d)

Does not cover notably:
  - unsigned RPM referenced by (re)signed repomd

In some cases Yum does not give an error, but dies because of an uncaught exception, which makes this check quite brittle, but in the worst case if messages change, we still fallback to the original "Error installing packages" message.