### PR TITLE
CP-311882: Remove safe mode boot option

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1053,8 +1053,7 @@ def prepFallback(mounts, primary_disk, primary_partnum):
 
 def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, serial, boot_serial, host_config, primary_disk, disk_label_suffix):
     short_version = kernelShortVersion(xen_kernel_version)
-    common_xen_params = "dom0_mem=%dM,max:%dM" % ((host_config['dom0-mem'],) * 2)
-    common_xen_unsafe_params = "watchdog dom0_max_vcpus=1-%d" % host_config['dom0-vcpus']
+    common_xen_params = "dom0_mem=%dM,max:%dM watchdog dom0_max_vcpus=1-%d" % ((host_config['dom0-mem'],) * 2, host_config['dom0-vcpus'])
     xen_mem_params = "crashkernel=512M,below=4G"
 
     # CA-103933 - AMD PCI-X Hypertransport Tunnel IOAPIC errata
@@ -1078,7 +1077,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
         common_kernel_params += " rd.auto"
 
     e = bootloader.MenuEntry(hypervisor="/boot/xen.efi",
-                             hypervisor_args=' '.join([common_xen_params, common_xen_unsafe_params, xen_mem_params, "console=vga vga=mode-0x0311"]),
+                             hypervisor_args=' '.join([common_xen_params, xen_mem_params, "console=vga vga=mode-0x0311"]),
                              kernel="/boot/vmlinuz-%s-xen" % short_version,
                              kernel_args=' '.join([common_kernel_params, kernel_console_params, "console=tty0 quiet vga=785 splash plymouth.ignore-serial-consoles"]),
                              initrd="/boot/initrd-%s-xen.img" % short_version, title=MY_PRODUCT_BRAND,
@@ -1090,7 +1089,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
         xen_serial_params = "%s console=%s,vga" % (serial.xenFmt(), serial.port)
 
         e = bootloader.MenuEntry(hypervisor="/boot/xen.efi",
-                                 hypervisor_args=' '.join([xen_serial_params, common_xen_params, common_xen_unsafe_params, xen_mem_params]),
+                                 hypervisor_args=' '.join([xen_serial_params, common_xen_params, xen_mem_params]),
                                  kernel="/boot/vmlinuz-%s-xen" % short_version,
                                  kernel_args=' '.join([common_kernel_params, "console=tty0", kernel_console_params]),
                                  initrd="/boot/initrd-%s-xen.img" % short_version, title=MY_PRODUCT_BRAND+" (Serial)",
@@ -1108,7 +1107,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
     boot_config.append("memtest", e)
 
     e = bootloader.MenuEntry(hypervisor="/boot/xen-fallback.efi",
-                             hypervisor_args=' '.join([common_xen_params, common_xen_unsafe_params, xen_mem_params]),
+                             hypervisor_args=' '.join([common_xen_params, xen_mem_params]),
                              kernel="/boot/vmlinuz-fallback",
                              kernel_args=' '.join([common_kernel_params, kernel_console_params, "console=tty0"]),
                              initrd="/boot/initrd-fallback.img",
@@ -1118,7 +1117,7 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
     boot_config.append("fallback", e)
     if serial:
         e = bootloader.MenuEntry(hypervisor="/boot/xen-fallback.efi",
-                                 hypervisor_args=' '.join([xen_serial_params, common_xen_params, common_xen_unsafe_params, xen_mem_params]),
+                                 hypervisor_args=' '.join([xen_serial_params, common_xen_params, xen_mem_params]),
                                  kernel="/boot/vmlinuz-fallback",
                                  kernel_args=' '.join([common_kernel_params, "console=tty0", kernel_console_params]),
                                  initrd="/boot/initrd-fallback.img",

--- a/backend.py
+++ b/backend.py
@@ -1055,9 +1055,6 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
     short_version = kernelShortVersion(xen_kernel_version)
     common_xen_params = "dom0_mem=%dM,max:%dM" % ((host_config['dom0-mem'],) * 2)
     common_xen_unsafe_params = "watchdog dom0_max_vcpus=1-%d" % host_config['dom0-vcpus']
-    safe_xen_params = ("nosmp noreboot noirqbalance no-mce no-bootscrub "
-                       "no-numa no-hap no-mmcfg max_cstate=0 "
-                       "nmi=ignore allow_unsafe")
     xen_mem_params = "crashkernel=512M,below=4G"
 
     # CA-103933 - AMD PCI-X Hypertransport Tunnel IOAPIC errata
@@ -1102,14 +1099,6 @@ def buildBootLoaderMenu(mounts, xen_version, xen_kernel_version, boot_config, se
         boot_config.append("xe-serial", e)
         if boot_serial:
             boot_config.default = "xe-serial"
-        e = bootloader.MenuEntry(hypervisor="/boot/xen.efi",
-                                 hypervisor_args=' '.join([safe_xen_params, common_xen_params, xen_serial_params]),
-                                 kernel="/boot/vmlinuz-%s-xen" % short_version,
-                                 kernel_args=' '.join(["earlyprintk=xen", common_kernel_params, "console=tty0", kernel_console_params]),
-                                 initrd="/boot/initrd-%s-xen.img" % short_version, title=MY_PRODUCT_BRAND+" in Safe Mode",
-                                 root=constants.rootfs_label%disk_label_suffix)
-        e.entry_format = Grub2Format.XEN_BOOT
-        boot_config.append("safe", e)
 
     e = bootloader.MenuEntry(hypervisor="", hypervisor_args="", kernel="/boot/memtest86+x64.efi",
                             kernel_args="",

--- a/bootloader/grub.cfg
+++ b/bootloader/grub.cfg
@@ -13,12 +13,6 @@ menuentry "no-serial" {
     xen_module /install.img
 }
 
-menuentry "safe" {
-    xen_hypervisor /boot/xen.efi dom0_max_vcpus=1-16 dom0_mem=max:8192M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep
-    xen_module /boot/vmlinuz console=hvc0 console=tty0
-    xen_module /install.img
-}
-
 menuentry "memtest" {
     linux /boot/memtest86+x64.efi
 }


### PR DESCRIPTION
Safe mode is generally untested and not used, if a customer experiences issues they should contact support rather that attempting to use safe mode.